### PR TITLE
Fix incorrect Korean translation

### DIFF
--- a/NT Cybernetics/Localization/Korean/Korean.xml
+++ b/NT Cybernetics/Localization/Korean/Korean.xml
@@ -4,10 +4,10 @@
 <!-- ITEMS -->
 
 <entityname.cyberarm>사이버 팔</entityname.cyberarm>
-<entitydescription.cyberarm>금속과 전자부품으로 만들어진 팔. 피가 나지 않습니다. 절단 후 설치하여 사용하십시오.</entitydescription.cyberarm>
+<entitydescription.cyberarm>금속과 전자부품으로 만들어진 팔. 피가 나지 않습니다. 해당 부위를 절단한 후 설치하십시오.</entitydescription.cyberarm>
 
 <entityname.cyberleg>사이버 다리</entityname.cyberleg>
-<entitydescription.cyberleg>금속과 전자부품으로 만든 다리. 피가 나지 않습니다. 절단 후 설치하여 사용하십시오.</entitydescription.cyberleg>
+<entitydescription.cyberleg>금속과 전자부품으로 만든 다리. 피가 나지 않습니다. 해당 부위를 절단한 후 설치하십시오.</entitydescription.cyberleg>
 
 <!-- AFFLICTIONS -->
 
@@ -15,10 +15,10 @@
 <afflictiondescription.ntc_cyberlimb></afflictiondescription.ntc_cyberlimb>
 
 <afflictionname.ntc_cyberarm>사이버 팔</afflictionname.ntc_cyberarm>
-<afflictiondescription.ntc_cyberarm>팔은 금속과 전자부품으로 만들어졌습니다.</afflictiondescription.ntc_cyberarm>
+<afflictiondescription.ntc_cyberarm>팔이 금속과 전자부품으로 만들어졌습니다.</afflictiondescription.ntc_cyberarm>
 
 <afflictionname.ntc_cyberleg>사이버 다리</afflictionname.ntc_cyberleg>
-<afflictiondescription.ntc_cyberleg>다리는 금속과 전자부품으로 만들어졌습니다.</afflictiondescription.ntc_cyberleg>
+<afflictiondescription.ntc_cyberleg>다리가 금속과 전자부품으로 만들어졌습니다.</afflictiondescription.ntc_cyberleg>
 
 
 <afflictionname.ntc_loosescrews>나사가 느슨함</afflictionname.ntc_loosescrews>

--- a/NT Surgery Plus/Localization/Korean/Korean.xml
+++ b/NT Surgery Plus/Localization/Korean/Korean.xml
@@ -18,7 +18,7 @@
 <entityname.brainjar>두뇌 항아리</entityname.brainjar>
 <entitydescription.brainjar>이식용 뇌를 무기한 보관할 수 있는 용기</entitydescription.brainjar>
 
-<entityname.surgicaldrapes>수술용 커튼</entityname.surgicaldrapes>
+<entityname.surgicaldrapes>수술용 덮개</entityname.surgicaldrapes>
 <entitydescription.surgicaldrapes>수술 중 감염을 방지하기 위한 멸균 시트.</entitydescription.surgicaldrapes>
 
 <entityname.skillbooksurgery>'의료 부정 행위'</entityname.skillbooksurgery>

--- a/Neurotrauma/Localization/Korean/Korean.xml
+++ b/Neurotrauma/Localization/Korean/Korean.xml
@@ -7,7 +7,7 @@
   <entityname.aed>자동 제세동기</entityname.aed>
   <entitydescription.aed>심장에 전기충격을 가하여 부정맥을 안정화시키는 의료기기. 의료 교육이 거의 또는 전혀 필요하지 않습니다. 심정지 환자에게 사용하십시오.</entitydescription.aed>
   <entityname.bvm>앰부 백</entityname.bvm>
-  <entitydescription.bvm>백 밸브 마스크(BVM)는 호흡을 하지 않거나 적절하게 호흡하지 않는 환자에게 양압 환기를 제공하기 위해 일반적으로 사용되는 휴대용 장치입니다.</entitydescription.bvm>
+  <entitydescription.bvm>백 밸브 마스크는 호흡을 하지 않거나 적절하게 호흡하지 않는 환자에게 양압 환기를 제공하기 위해 일반적으로 사용되는 휴대용 장치입니다.</entitydescription.bvm>
   <entityname.autocpr>오토펄스</entityname.autocpr>
   <entitydescription.autocpr>배터리로 구동되는 자동화된 휴대용 심폐 소생 장치.</entitydescription.autocpr>
   <entityname.bloodanalyzer>혈액학 분석기</entityname.bloodanalyzer>
@@ -30,13 +30,13 @@
   <entitydescription.advhemostat>수술 중 혈관을 조일 때 사용하는 도구입니다.</entitydescription.advhemostat>
   <entityname.advretractors>스킨 리트렉터</entityname.advretractors>
   <entitydescription.advretractors>수술 중 피부를 절개 된 상태로 고정시키는 데 사용되는 도구입니다.</entitydescription.advretractors>
-  <entityname.tweezers>족집게</entityname.tweezers>
+  <entityname.tweezers>집게</entityname.tweezers>
   <entitydescription.tweezers>총알 또는 손상되고 괴사된 조직을 제거할 수 있는 작은 도구입니다.</entitydescription.tweezers>
   <entityname.surgerysaw>외과용 톱</entityname.surgerysaw>
   <entitydescription.surgerysaw>뼈를 절단하는 데 사용하는 도구.</entitydescription.surgerysaw>
   <entityname.suture>봉합용 실</entityname.suture>
   <entitydescription.suture>상처와 수술 절개 부위를 봉합하기 위한 생분해성 봉합용 실.</entitydescription.suture>
-  <entityname.surgicaldrill>수술 드릴</entityname.surgicaldrill>
+  <entityname.surgicaldrill>수술용 드릴</entityname.surgicaldrill>
   <entitydescription.surgicaldrill>뼈를 뚫는 데 사용하는 도구입니다.</entitydescription.surgicaldrill>
   <entityname.osteosynthesisimplants>골접합 임플란트</entityname.osteosynthesisimplants>
   <entitydescription.osteosynthesisimplants>골절을 치료하기 위해 골접합 수술에 사용되는 티타늄 임플란트.</entitydescription.osteosynthesisimplants>
@@ -56,30 +56,30 @@
   <entitydescription.organscalpel_brain>뇌를 적출하기 위한 특수 메스.</entitydescription.organscalpel_brain>
   <!-- /// Treatments /// -->
   <entityname.mannitol>만니톨</entityname.mannitol>
-  <entitydescription.mannitol>설탕 주정 알코올의 일종. 신경 외상으로부터 회복을 돕기 위해 사용됩니다. 장기 손상을 일으킬 수 있음.</entitydescription.mannitol>
+  <entitydescription.mannitol>당 환원 알코올의 일종. 신경 외상으로부터 회복을 돕기 위해 사용됩니다. 장기 손상을 일으킬 수 있습니다.</entitydescription.mannitol>
   <entityname.streptokinase>스트렙토키나제</entityname.streptokinase>
   <entitydescription.streptokinase>혈전을 분해하는 혈전 용해 효소. 심장 마비를 치료하는 데 사용됩니다. 혈액 응고를 감소시킵니다.</entitydescription.streptokinase>
   <entityname.immunosuppressant>아자티오프린</entityname.immunosuppressant>
   <entitydescription.immunosuppressant>장기 거부반응 예방용 면역억제제.</entitydescription.immunosuppressant>
   <entityname.thiamine>티아민</entityname.thiamine>
-  <entitydescription.thiamine>비타민 B1으로 알려진 이 알약은 장기(Organ) 치유에 도움이 됩니다.</entitydescription.thiamine>
+  <entitydescription.thiamine>비타민 B1으로 알려진 이 알약은 장기 치유에 도움이 됩니다.</entitydescription.thiamine>
   <entityname.ointment>항생제 연고</entityname.ointment>
   <entitydescription.ointment>화상 및 경미한 감염으로부터 회복을 촉진하는 살균력이 뛰어난 젤.</entitydescription.ointment>
   <entityname.endovascballoon>혈관 내 풍선</entityname.endovascballoon>
-  <entitydescription.endovascballoon>파열된 주요 동맥에 풍선을 삽입합니다. 그것은 혈류를 차단하지만 출혈을 멈출 것입니다.</entitydescription.endovascballoon>
+  <entitydescription.endovascballoon>파열된 주요 동맥에 풍선을 삽입합니다. 그것은 혈류를 차단하지만 출혈을 멈추는 효과가 있습니다.</entitydescription.endovascballoon>
   <entityname.medstent>의료용 스텐트</entityname.medstent>
-  <entitydescription.medstent>대동맥 파열 후 혈관 내 풍선을 삽입한 후 대동맥에 삽입하는 플라스틱 튜브.</entitydescription.medstent>
+  <entitydescription.medstent>파열된 대동맥에 혈관 내 풍선을 삽입한 이후 삽입하는 플라스틱 튜브.</entitydescription.medstent>
   <entityname.tourniquet>지혈대</entityname.tourniquet>
   <entitydescription.tourniquet>사지에 압력을 가하여 혈류를 감소시키는 장치. 일반적으로 사지에 큰 출혈이 있는 경우에 사용됩니다. 머리에 사용하면 안됩니다.</entitydescription.tourniquet>
   <entityname.drainage>배액관</entityname.drainage>
   <entitydescription.drainage>기흉 교정 수술 시 흉강에서 공기를 빼냅니다.</entitydescription.drainage>
   <entityname.needle>바늘</entityname.needle>
-  <entitydescription.needle>공기나 액체를 흉막강이나 심낭 밖으로 배출시키는 감압 밸브가 있는 바늘</entitydescription.needle>
+  <entitydescription.needle>흉막강이나 심낭에서 공기나 액체를 밖으로 배출시키는 감압 밸브가 있는 바늘</entitydescription.needle>
   <entityname.ringerssolution>링거 액</entityname.ringerssolution>
-  <entitydescription.ringerssolution>저혈압이나 체액 손실을 치료하기 위해 물에 녹인 여러 염류 용액. 혈액에 등장성(isotonic).</entitydescription.ringerssolution>
-  <entityname.antiseptic>패혈 방지제</entityname.antiseptic>
+  <entitydescription.ringerssolution>저혈압이나 체액 손실을 치료하기 위해 물에 녹인 여러 염류 용액. 혈액과 삼투압이 같습니다.</entitydescription.ringerssolution>
+  <entityname.antiseptic>소독제</entityname.antiseptic>
   <!-- <entitydescription.antiseptic></entitydescription.antiseptic> -->
-  <entityname.antisepticspray>패혈 방지제 스프레이</entityname.antisepticspray>
+  <entityname.antisepticspray>소독제 스프레이</entityname.antisepticspray>
   <!-- <entitydescription.antisepticspray></entitydescription.antisepticspray> -->
   <entityname.propofol>프로포폴</entityname.propofol>
   <entitydescription.propofol>의식 수준을 감소시키고 사건에 대한 기억력 부족을 초래하는 속효성 약물입니다. 그 용도에는 전신 마취의 시작과 유지가 포함됩니다.</entitydescription.propofol>
@@ -159,7 +159,7 @@
 <entityname.organtoolbox>저온 보관함</entityname.organtoolbox>
 <entitydescription.organtoolbox>소중한 이식용 장기를 보관하는 곳</entitydescription.organtoolbox>
 <entityname.bodybag>바디 백</entityname.bodybag>
-<entitydescription.bodybag>사람을 더 빨리 끌 수 있습니다.</entitydescription.bodybag>
+<entitydescription.bodybag>사람을 더 빨리 옮길 수 있습니다.</entitydescription.bodybag>
 <entityname.stasisbag>스테이시스 백</entityname.stasisbag>
 <entitydescription.stasisbag>대부분의 생물학적 과정이 일어나는 것을 막습니다.</entitydescription.stasisbag>
 
@@ -220,9 +220,9 @@
 <afflictiondescription.tachycardia>심장이 놀라울 정도로 빠르게 뛰고 있습니다.</afflictiondescription.tachycardia>
 <afflictionname.fibrillation>불규칙한 심장박동</afflictionname.fibrillation>
 <afflictiondescription.fibrillation>심장이 펄럭이며 떨리는 방식으로 뛰고 있습니다.</afflictiondescription.fibrillation>
-<afflictionname.cardiacarrest>심장 마비(Cardiac arrest)</afflictionname.cardiacarrest>
+<afflictionname.cardiacarrest>심정지</afflictionname.cardiacarrest>
 <afflictiondescription.cardiacarrest>박동이 없습니다.</afflictiondescription.cardiacarrest>
-<afflictionname.heartattack>심장 마비(Heart attack)</afflictionname.heartattack>
+<afflictionname.heartattack>심장 마비</afflictionname.heartattack>
 <afflictiondescription.heartattack></afflictiondescription.heartattack>
 <afflictionname.heartdamage>심장 손상</afflictionname.heartdamage>
 <afflictiondescription.heartdamage></afflictiondescription.heartdamage>
@@ -232,7 +232,7 @@
 <afflictiondescription.heartremoved>심장은 수술로 제거되었습니다.</afflictiondescription.heartremoved>
 
 <!-- /// Brain /// -->
-<afflictionname.cerebralhypoxia>신경 외상(Neurotrauma)</afflictionname.cerebralhypoxia>
+<afflictionname.cerebralhypoxia>신경 외상</afflictionname.cerebralhypoxia>
 <afflictiondescription.cerebralhypoxia></afflictiondescription.cerebralhypoxia>
 <afflictioncauseofdeath.cerebralhypoxia>신경 외상으로 인한 사망</afflictioncauseofdeath.cerebralhypoxia>
 <afflictioncauseofdeathself.cerebralhypoxia>당신은 신경 외상으로 사망했습니다.</afflictioncauseofdeathself.cerebralhypoxia>
@@ -264,7 +264,7 @@
 <afflictiondescription.alkalosis></afflictiondescription.alkalosis>
 <afflictionname.acidosis>산증</afflictionname.acidosis>
 <afflictiondescription.acidosis></afflictiondescription.acidosis>
-<afflictionname.rili>방사선 유발 폐 손상</afflictionname.rili>
+<afflictionname.rili>방사선으로 인한 폐 손상</afflictionname.rili>
 <afflictiondescription.rili></afflictiondescription.rili>
 <afflictionname.pneumothorax>기흉</afflictionname.pneumothorax>
 <afflictiondescription.pneumothorax></afflictiondescription.pneumothorax>
@@ -286,10 +286,10 @@
 <!-- /// bones /// -->
 <afflictionname.bonedamage>뼈 손상</afflictionname.bonedamage>
 <afflictiondescription.bone></afflictiondescription.bone>
-<afflictionname.bonedeath>죽은 뼈</afflictionname.bonedeath>
+<afflictionname.bonedeath>뼈 괴사</afflictionname.bonedeath>
 <afflictiondescription.bonedeath></afflictiondescription.bonedeath>
 <afflictionname.bonegrowth>뼈 재생 촉진</afflictionname.bonegrowth>
-<afflictiondescription.bonegrowth>뼈 재생이 촉진되었습니다. 죽은 뼈가 치유되기 위해서는 이 고통이 모든 신체 부위에 있어야 합니다.</afflictiondescription.bonegrowth>
+<afflictiondescription.bonegrowth>뼈 재생이 촉진되었습니다. 괴사된 뼈가 치유되기 위해서는 모든 팔과 다리에 이 증상이 나타나도록 해야 합니다.</afflictiondescription.bonegrowth>
 
 <!-- /// liver /// -->
 <afflictionname.liverdamage>간 손상</afflictionname.liverdamage>
@@ -305,13 +305,13 @@
 <afflictionname.clampedbleeders>혈관 조임</afflictionname.clampedbleeders>
 <afflictiondescription.clampedbleeders>절개로 유발된 출혈이 멈췄습니다.</afflictiondescription.clampedbleeders>
 <afflictionname.arteriesclamp>동맥 조임</afflictionname.arteriesclamp>
-<afflictiondescription.arteriesclamp>동맥으로부터의 출혈은 멈췄지만 사지로 가는 혈류는 심각하게 감소합니다.</afflictiondescription.arteriesclamp>
+<afflictiondescription.arteriesclamp>동맥으로부터의 출혈은 멈췄지만 사지로 가는 혈류가 심각하게 감소합니다.</afflictiondescription.arteriesclamp>
 <afflictionname.balloonedaorta>풍선이 삽입된 대동맥</afflictionname.balloonedaorta>
-<afflictiondescription.balloonedaorta>대동맥은 출혈을 멈췄지만 사지와 장기로 가는 혈류는 사라졌습니다.</afflictiondescription.balloonedaorta>
-<afflictionname.boneclamp>부목</afflictionname.boneclamp>
-<afflictiondescription.boneclamp>골절부위가 부목으로 고정되었습니다.</afflictiondescription.boneclamp>
+<afflictiondescription.balloonedaorta>대동맥은 출혈을 멈췄지만 사지와 장기로 가는 혈류가 사라졌습니다.</afflictiondescription.balloonedaorta>
+<afflictionname.boneclamp>뼈 클램프</afflictionname.boneclamp>
+<afflictiondescription.boneclamp>골절부위가 뼈 클램프로 고정되었습니다.</afflictiondescription.boneclamp>
 <afflictionname.bandaged>붕대</afflictionname.bandaged>
-<afflictiondescription.bandaged>감염으로부터 보호하고 탈골된 뼈를 안정화시킵니다. 움직임이 약간 느려집니다.</afflictiondescription.bandaged>
+<afflictiondescription.bandaged>감염으로부터 보호하고 탈구된 뼈를 안정화시킵니다. 움직임이 약간 느려집니다.</afflictiondescription.bandaged>
 <afflictionname.dirtybandage>더러운 붕대</afflictionname.dirtybandage>
 <afflictiondescription.dirtybandage>감염으로부터 보호하는 데 사용되었지만 지금은 그 반대입니다.</afflictiondescription.dirtybandage>
 <afflictionname.gypsumcast>깁스로 고정됨</afflictionname.gypsumcast>
@@ -360,13 +360,13 @@
 <afflictiondescription.t_paralysis>환자는 마비되어 몸을 느끼지 못합니다.</afflictiondescription.t_paralysis>
 <afflictioncauseofdeath.t_paralysis>마비로 사망</afflictioncauseofdeath.t_paralysis>
 <afflictioncauseofdeathself.t_paralysis>당신은 마비로 사망했습니다.</afflictioncauseofdeathself.t_paralysis>
-<afflictionname.dislocation1>탈골</afflictionname.dislocation1>
+<afflictionname.dislocation1>탈구</afflictionname.dislocation1>
 <afflictiondescription.dislocation1>관절이 이렇게 휘어지면 안되는데...</afflictiondescription.dislocation1>
-<afflictionname.dislocation2>탈골</afflictionname.dislocation2>
+<afflictionname.dislocation2>탈구</afflictionname.dislocation2>
 <afflictiondescription.dislocation2>관절이 이렇게 휘어지면 안되는데...</afflictiondescription.dislocation2>
-<afflictionname.dislocation3>탈골</afflictionname.dislocation3>
+<afflictionname.dislocation3>탈구</afflictionname.dislocation3>
 <afflictiondescription.dislocation3>관절이 이렇게 휘어지면 안되는데...</afflictiondescription.dislocation3>
-<afflictionname.dislocation4>탈골</afflictionname.dislocation4>
+<afflictionname.dislocation4>탈구</afflictionname.dislocation4>
 <afflictiondescription.dislocation4>관절이 이렇게 휘어지면 안되는데...</afflictiondescription.dislocation4>
 <afflictionname.ll_arterialcut>대퇴동맥 출혈</afflictionname.ll_arterialcut>
 <afflictiondescription.ll_arterialcut>동맥이 손상되어 심각한 출혈을 유발합니다.</afflictiondescription.ll_arterialcut>
@@ -413,7 +413,7 @@
 <afflictiondescription.hemotransfusionshock></afflictiondescription.hemotransfusionshock>
 <afflictionname.foreignbody>이물질</afflictionname.foreignbody>
 <afflictiondescription.foreignbody></afflictiondescription.foreignbody>
-<afflictionname.tamponade>심장 압전</afflictionname.tamponade>
+<afflictionname.tamponade>심장눌림증</afflictionname.tamponade>
 <afflictiondescription.tamponade></afflictiondescription.tamponade>
 <afflictionname.internalbleeding>내부 출혈</afflictionname.internalbleeding>
 <afflictiondescription.internalbleeding></afflictiondescription.internalbleeding>
@@ -424,27 +424,27 @@
 <afflictionname.sym_paleskin>창백한 피부</afflictionname.sym_paleskin>
 <afflictiondescription.sym_paleskin>환자의 피부는 창백합니다.</afflictiondescription.sym_paleskin>
 <afflictionname.sym_lightheadedness>현기증</afflictionname.sym_lightheadedness>
-<afflictiondescription.sym_lightheadedness>환자는 현기증을 표현하고 있습니다.</afflictiondescription.sym_lightheadedness>
+<afflictiondescription.sym_lightheadedness>환자는 현기증을 겪고 있습니다.</afflictiondescription.sym_lightheadedness>
 <afflictionname.sym_blurredvision>흐린 시야</afflictionname.sym_blurredvision>
-<afflictiondescription.sym_blurredvision>환자는 흐린 시력을 표현하고 있습니다.</afflictiondescription.sym_blurredvision>
+<afflictiondescription.sym_blurredvision>환자는 시야가 흐려졌다고 호소하고 있습니다.</afflictiondescription.sym_blurredvision>
 <afflictionname.sym_confusion>착란</afflictionname.sym_confusion>
 <afflictiondescription.sym_confusion>환자는 방향 감각을 잃고 혼란스러워 보입니다.</afflictiondescription.sym_confusion>
 <afflictionname.sym_headache>두통</afflictionname.sym_headache>
-<afflictiondescription.sym_headache>환자는 두통을 표현하고 있습니다.</afflictiondescription.sym_headache>
+<afflictiondescription.sym_headache>환자는 두통을 호소하고 있습니다.</afflictiondescription.sym_headache>
 <afflictionname.sym_legswelling>다리 붓기</afflictionname.sym_legswelling>
 <afflictiondescription.sym_legswelling>환자의 다리가 부어 있습니다.</afflictiondescription.sym_legswelling>
-<afflictionname.sym_weakness>약점</afflictionname.sym_weakness>
-<afflictiondescription.sym_weakness>환자는 부위의 약점을 표현하고 있습니다.</afflictiondescription.sym_weakness>
+<afflictionname.sym_weakness>힘이 없음</afflictionname.sym_weakness>
+<afflictiondescription.sym_weakness>환자의 해당 부위에 힘이 없습니다.</afflictiondescription.sym_weakness>
 <afflictionname.sym_wheezing>쌕쌕거림</afflictionname.sym_wheezing>
 <afflictiondescription.sym_wheezing>환자의 호흡에서 높은 음의 소음이 발생합니다.</afflictiondescription.sym_wheezing>
 <afflictionname.sym_vomiting>구토</afflictionname.sym_vomiting>
 <afflictiondescription.sym_vomiting>환자는 주기적으로 구토를 합니다.</afflictiondescription.sym_vomiting>
-<afflictionname.sym_hematemesis>각혈</afflictionname.sym_hematemesis>
+<afflictionname.sym_hematemesis>피를 토함</afflictionname.sym_hematemesis>
 <afflictiondescription.sym_hematemesis>환자는 주기적으로 피를 토합니다.</afflictiondescription.sym_hematemesis>
 <afflictionname.fever>고열</afflictionname.fever>
 <afflictiondescription.fever>환자의 체온이 상승합니다.</afflictiondescription.fever>
 <afflictionname.sym_abdomdiscomfort>복부 불편</afflictionname.sym_abdomdiscomfort>
-<afflictiondescription.sym_abdomdiscomfort>환자는 복부 불편을 표현하고 있습니다.</afflictiondescription.sym_abdomdiscomfort>
+<afflictiondescription.sym_abdomdiscomfort>환자는 복부가 불편하다고 호소하고 있습니다.</afflictiondescription.sym_abdomdiscomfort>
 <afflictionname.sym_bloating>팽만감</afflictionname.sym_bloating>
 <afflictiondescription.sym_bloating>환자의 복부가 부풀어 올랐습니다.</afflictiondescription.sym_bloating>
 <afflictionname.sym_jaundice>황달</afflictionname.sym_jaundice>
@@ -452,29 +452,29 @@
 <afflictionname.sym_sweating>땀흘림</afflictionname.sym_sweating>
 <afflictiondescription.sym_sweating>환자가 과도하게 땀을 흘리고 있습니다.</afflictiondescription.sym_sweating>
 <afflictionname.sym_palpitations>심장이 두근거림</afflictionname.sym_palpitations>
-<afflictiondescription.sym_palpitations>환자는 심장이 두근거림을 표현하고 있습니다.</afflictiondescription.sym_palpitations>
+<afflictiondescription.sym_palpitations>환자는 심장이 두근거림을 호소하고 있습니다.</afflictiondescription.sym_palpitations>
 <afflictionname.sym_unconsciousness>무의식</afflictionname.sym_unconsciousness>
 <afflictiondescription.sym_unconsciousness>환자는 의식이 없습니다.</afflictiondescription.sym_unconsciousness>
 <afflictionname.inflammation>염증</afflictionname.inflammation>
 <afflictiondescription.inflammation>부위가 붉게 부어 오르며 따뜻합니다.</afflictiondescription.inflammation>
 <afflictionname.spasm>경련</afflictionname.spasm>
-<afflictiondescription.spasm>환자는 부위의 불규칙한 행동을 제어할 수 없습니다.</afflictiondescription.spasm>
+<afflictiondescription.spasm>환자는 해당 부위의 불규칙한 움직임을 제어할 수 없습니다.</afflictiondescription.spasm>
 <afflictionname.sym_craving>갈망</afflictionname.sym_craving>
 <afflictiondescription.sym_craving>환자는 충분히 행복합니다... 필요한 것을 얻는 한.</afflictiondescription.sym_craving>
 <afflictionname.onfire>불이야!</afflictionname.onfire>
 <afflictiondescription.onfire>환자가 산 채로 불타고 있습니다! 소화기를 잡아라!</afflictiondescription.onfire>
 <afflictionname.pain_chest>가슴 통증</afflictionname.pain_chest>
-<afflictiondescription.pain_chest>환자는 가슴에 날카롭고 찌르는 듯한 통증을 표현하고 있습니다.</afflictiondescription.pain_chest>
+<afflictiondescription.pain_chest>환자는 가슴에 날카롭고 찌르는 듯한 통증을 호소하고 있습니다.</afflictiondescription.pain_chest>
 <afflictionname.pain_abdominal>복통</afflictionname.pain_abdominal>
-<afflictiondescription.pain_abdominal>환자는 복부에 지속적인 통증을 표현하고 있습니다.</afflictiondescription.pain_abdominal>
+<afflictiondescription.pain_abdominal>환자는 복부에 지속적인 통증을 호소하고 있습니다.</afflictiondescription.pain_abdominal>
 <afflictionname.pain_extremity>심한 통증</afflictionname.pain_extremity>
 <afflictiondescription.pain_extremity>환자는 환부에 심한 통증을 호소하고 있습니다.</afflictiondescription.pain_extremity>
 <afflictionname.sym_nausea>메스꺼움</afflictionname.sym_nausea>
-<afflictiondescription.sym_nausea>피부는 축축하고 환자는 메스꺼움을 느낍니다.</afflictiondescription.sym_nausea>
+<afflictiondescription.sym_nausea>환자는 메스꺼움을 느끼며 피부가 축축합니다.</afflictiondescription.sym_nausea>
 <afflictionname.luabotomy>Lua 없음</afflictionname.luabotomy>
 <afflictiondescription.luabotomy>Lua가 실행되지 않습니다. 즉, Neurotrauma 및 이를 사용하는 다른 모드가 작동하지 않습니다. 사용하려는 모드의 워크샵 페이지를 읽으십시오.</afflictiondescription.luabotomy>
 <afflictionname.traumaticshock>외상성 쇼크</afflictionname.traumaticshock>
-<afflictiondescription.traumaticshock>환자는 심한 통증과 스트레스를 경험합니다.</afflictiondescription.traumaticshock>
+<afflictiondescription.traumaticshock>환자는 심한 통증과 스트레스를 겪고 있습니다.</afflictiondescription.traumaticshock>
 <afflictionname.analgesia>무통</afflictionname.analgesia>
 <afflictiondescription.analgesia>통증을 느끼지 않습니다.</afflictiondescription.analgesia>
 <afflictionname.anesthesia>마취</afflictionname.anesthesia>


### PR DESCRIPTION
NT Cybernetics: Fix incorrect Korean translation (+2 squashed commit)

Squashed commit:
[b5170e4] Neurotrauma: Fix incorrect Korean translation
[5a96f07] NT Surgery Plus: Fix incorrect Korean translation of entityname.surgicaldrapes