### PR TITLE
Update saline's recipe

### DIFF
--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -2967,14 +2967,12 @@
         <Price storeidentifier="merchantmine"/>
         <Price storeidentifier="merchantmedical" multiplier="0.9"/>
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="15">
-        <RequiredSkill identifier="medical" level="5"/>
-        <RequiredItem identifier="sodium"/>
-        <RequiredItem identifier="chlorine"/>
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="2" >
+        <RequiredSkill identifier="medical" level="5" />
+        <RequiredItem identifier="sodium"  />
+        <RequiredItem identifier="chlorine" amount="2" />
       </Fabricate>
-      <Deconstruct time="20">
-        <Item identifier="sodium" copycondition="true" mincondition="0.1"/>
-      </Deconstruct>
+      <Deconstruct time="5"/>
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="960,640,64,64" origin="0.5,0.5"/>
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,261,83,46" depth="0.6"
               origin="0.5,0.5"/>


### PR DESCRIPTION
Now vanilla saline's recipe need 2x chlorine and 1x sodium to craft 2 salines, but deconstruct them will get nothing.