### PR TITLE
Fix surgery book using wrong target

### DIFF
--- a/NT Surgery Plus/Lua/Scripts/items.lua
+++ b/NT Surgery Plus/Lua/Scripts/items.lua
@@ -204,7 +204,7 @@ end
 end,1)
 
 Hook.Add("surgerybookgiveskill", "givesurgerybookskill", function (effect, deltaTime, item, targets, worldPosition)
-    local character = targets[2]
+    local character = targets[3]
     if NT.Config.NTSPenableSurgerySkill then
         HF.GiveSkill(character,"surgery",8)
         HF.GiveSkill(character,"medical",2)


### PR DESCRIPTION
Looks like latest baro update made the list of targets also include the item itself automatically, breaking the order of this