### PR TITLE
Add a config option to change skill check formula

### DIFF
--- a/Neurotrauma/Lua/Scripts/Client/configgui.lua
+++ b/Neurotrauma/Lua/Scripts/Client/configgui.lua
@@ -288,6 +288,13 @@ NT.ShowGUI = function ()
         OnChanged()
     end
 
+    local vanillaSkillCheck = GUI.TickBox(GUI.RectTransform(Vector2(1, 0.2), config.Content.RectTransform), "Change the skill check algorithm to the vanilla one")
+    vanillaSkillCheck.Selected = NT.Config.vanillaSkillCheck
+    vanillaSkillCheck.OnSelected = function ()
+        NT.Config.vanillaSkillCheck = vanillaSkillCheck.State == 3
+        OnChanged()
+    end
+
     -- Surgery Plus specific options
     if NTSP~=nil then
 

--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -427,12 +427,12 @@ end
 
 function HF.GetSkillRequirementMet(character,skilltype,requiredamount)
     local skilllevel = HF.GetSkillLevel(character,skilltype)
-    return HF.Chance(HF.Clamp(skilllevel/requiredamount,0,1))
+    return HF.Chance(HF.Clamp((100-(requiredamount-skilllevel))/100,0,1))
 end
 
 function HF.GetSurgerySkillRequirementMet(character,requiredamount)
     local skilllevel = HF.GetSurgerySkill(character)
-    return HF.Chance(HF.Clamp(skilllevel/requiredamount,0,1))
+    return HF.Chance(HF.Clamp((100-(requiredamount-skilllevel))/100,0,1))
 end
 
 function HF.GetSurgerySkill(character)

--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -427,12 +427,18 @@ end
 
 function HF.GetSkillRequirementMet(character,skilltype,requiredamount)
     local skilllevel = HF.GetSkillLevel(character,skilltype)
-    return HF.Chance(HF.Clamp((100-(requiredamount-skilllevel))/100,0,1))
+    if NT.Config.vanillaSkillCheck then
+        return HF.Chance(HF.Clamp((100-(requiredamount-skilllevel))/100,0,1))
+    end
+    return HF.Chance(HF.Clamp(skilllevel/requiredamount,0,1))
 end
 
 function HF.GetSurgerySkillRequirementMet(character,requiredamount)
     local skilllevel = HF.GetSurgerySkill(character)
-    return HF.Chance(HF.Clamp((100-(requiredamount-skilllevel))/100,0,1))
+    if NT.Config.vanillaSkillCheck then
+        return HF.Chance(HF.Clamp((100-(requiredamount-skilllevel))/100,0,1))
+    end
+    return HF.Chance(HF.Clamp(skilllevel/requiredamount,0,1))
 end
 
 function HF.GetSurgerySkill(character)

--- a/Neurotrauma/Lua/defaultconfig.lua
+++ b/Neurotrauma/Lua/defaultconfig.lua
@@ -17,6 +17,7 @@ config.organDamageGain = 1
 config.fibrillationSpeed = 1
 config.gangrenespeed = 1
 
+config.vanillaSkillCheck = false
 config.disableBotAlgorithms = true
 
 config.NTSPenableSurgicalInfection = true


### PR DESCRIPTION
Adds a config option to change the formula for the skill check to a simplified (but should be functionally the same) version of Barotrauma's.