### PR TITLE
Make stasis bag swappable against diving suits

### DIFF
--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -1877,7 +1877,7 @@
     </Wearable>
     <aitarget maxsightrange="50" />
   </Item>
-  <Item name="" identifier="stasisbag" category="Equipment" tags="provocative,mediumitem" scale="0.9" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" equipconfirmationtext="stasisbagequipconfirmation">
+  <Item name="" identifier="stasisbag" category="Equipment" tags="provocative,mediumitem,diving" scale="0.9" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" equipconfirmationtext="stasisbagequipconfirmation">
     <Price baseprice="1500" soldbydefault="false">
       <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
     </Price>


### PR DESCRIPTION
To put a stasis bag on someone outside, you have to first remove their diving suit and _then_ put on the stasis bag, because the diving suit has `allowdroppingswapwith="diving"`.

This PR adds the tag `diving` to the stasis bag, so that it can be swapped against diving suits by just dragging it on to the diving suit.

I don't _think_ this causes any other issues, but it's not super clear to me what the `diving` tag is used for apart from this.

Awesome mod, btw! Definitely the best fun I've had in this game.