### PR TITLE
Syringe Fix

### DIFF
--- a/NT Surgery Plus/Xml/items.xml
+++ b/NT Surgery Plus/Xml/items.xml
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
-
   <!-- medical misconduct -->
   <Item name="" identifier="skillbooksurgery" category="Equipment" Tags="smallitem,skillbook" maxstacksize="8" scale="0.5" impactsoundtag="impact_soft">
     <PreferredContainer primary="storagecab,crewcab" />
     <PreferredContainer secondary="locker" />
-    <Price baseprice="350" buyingpricemodifier="2.5" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" maxavailable="1"/>
+    <Price baseprice="350" buyingpricemodifier="2.5">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" maxavailable="1" />
     </Price>
     <Deconstruct time="20">
       <Item identifier="carbon" />
@@ -23,203 +22,174 @@
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
   <!-- mannitol plus, talent item -->
-  <Item name="" identifier="mannitolplus" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab"/>
-    <Price baseprice="500" soldbydefault="false">
-    </Price>
+  <Item name="" identifier="mannitolplus" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" />
+    <Price baseprice="500" soldbydefault="false"></Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="60" requiresrecipe="true">
-        <RequiredSkill identifier="medical" level="80"/>
-        <RequiredItem identifier="mannitol"/>
-        <RequiredItem identifier="adrenaline"/>
-        <RequiredItem identifier="liquidoxygenite"/>
-        <RequiredItem identifier="stabilozine"/>
+      <RequiredSkill identifier="medical" level="80" />
+      <RequiredItem identifier="mannitol" />
+      <RequiredItem identifier="adrenaline" />
+      <RequiredItem identifier="liquidoxygenite" />
+      <RequiredItem identifier="stabilozine" />
     </Fabricate>
     <Deconstruct time="20">
-        <Item identifier="mannitol" copycondition="true" mincondition="0.1"/>
-        <Item identifier="adrenaline" copycondition="true" mincondition="0.1"/>
+      <Item identifier="mannitol" copycondition="true" mincondition="0.1" />
+      <Item identifier="adrenaline" copycondition="true" mincondition="0.1" />
     </Deconstruct>
-    <SuitableTreatment identifier="cerebralhypoxia" suitability="30"/>
-    <InventoryIcon texture="%ModDir:2776270649%/Images/InventoryItemIconAtlas.png" sourcerect="128,128,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir:2776270649%/Images/InGameItemIconAtlas.png" sourcerect="640,128,128,128" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="60"></RequiredSkill>
-        <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="afmannitol" amount="5"/>
-          <ReduceAffliction identifier="cerebralhypoxia" amount="3"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-            <Affliction identifier="afmannitol" amount="3"/>
-          <ReduceAffliction identifier="cerebralhypoxia" amount="1.5"/>
-        </StatusEffect>
-        <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-        </StatusEffect>
+    <SuitableTreatment identifier="cerebralhypoxia" suitability="30" />
+    <InventoryIcon texture="%ModDir:2776270649%/Images/InventoryItemIconAtlas.png" sourcerect="128,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir:2776270649%/Images/InGameItemIconAtlas.png" sourcerect="640,128,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+      <RequiredSkill identifier="medical" level="60"></RequiredSkill>
+      <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+      <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
+      <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
+        <Affliction identifier="afmannitol" amount="5" />
+        <ReduceAffliction identifier="cerebralhypoxia" amount="3" />
+      </StatusEffect>
+      <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
+        <Affliction identifier="afmannitol" amount="3" />
+        <ReduceAffliction identifier="cerebralhypoxia" amount="1.5" />
+      </StatusEffect>
+      <StatusEffect type="OnSuccess" target="UseTarget">
+        <Conditional entitytype="eq Character"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+      </StatusEffect>
+      <StatusEffect type="OnFailure" target="UseTarget">
+        <Conditional entitytype="eq Character"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+        <Affliction identifier="stun" amount="0.1" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
-    <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="10">
-            <Affliction identifier="afmannitol" amount="3"/>
-            <ReduceAffliction identifier="cerebralhypoxia" amount="1.5"/>
-        </StatusEffect>
-    </Projectile>
+    <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
   </Item>
-
   <!-- experimental treatment, talent item -->
-  <Item name="" identifier="experimentaltreatment" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab"/>
-    <Price baseprice="300" soldbydefault="false">
-    </Price>
+  <Item name="" identifier="experimentaltreatment" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" />
+    <Price baseprice="300" soldbydefault="false"></Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="30" requiresrecipe="true" amount="4">
-        <RequiredSkill identifier="medical" level="60"/>
-        <RequiredSkill identifier="surgery" level="40"/>
-        <RequiredItem identifier="propofol"/>
-        <RequiredItem identifier="cyanide"/>
-        <RequiredItem identifier="adrenaline"/>
-        <RequiredItem identifier="uranium"/>
+      <RequiredSkill identifier="medical" level="60" />
+      <RequiredSkill identifier="surgery" level="40" />
+      <RequiredItem identifier="propofol" />
+      <RequiredItem identifier="cyanide" />
+      <RequiredItem identifier="adrenaline" />
+      <RequiredItem identifier="uranium" />
     </Fabricate>
-    <Deconstruct time="10"/>
-    <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="0,192,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/MainAtlas.png" sourcerect="256,256,128,128" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect tags="medical" type="OnUse" target="UseTarget"/>
-        <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-        </StatusEffect>
+    <Deconstruct time="10" />
+    <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="0,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/MainAtlas.png" sourcerect="256,256,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+      <StatusEffect tags="medical" type="OnUse" target="UseTarget" />
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
-    <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-    </Projectile>
+    <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
   </Item>
-
   <!-- artifical brain transplant, talent item -->
   <Item name="" identifier="artificialbrain" description="" scale="0.3" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="1.5" Tags="smallitem,organ,petfood1,petfood2,petfood3,braintransplant">
-    <Price baseprice="0" soldbydefault="false">
-    </Price>
-    <Sprite texture="%ModDir:2776270649%/Images/InGameItemIconAtlas.png" sourcerect="272,480,78,60" depth="0.6" origin="0.5,0.5"/>
-    <Body width="39" height="25" density="13"/>
+    <Price baseprice="0" soldbydefault="false"></Price>
+    <Sprite texture="%ModDir:2776270649%/Images/InGameItemIconAtlas.png" sourcerect="272,480,78,60" depth="0.6" origin="0.5,0.5" />
+    <Body width="39" height="25" density="13" />
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="60" requiresrecipe="true">
-        <RequiredSkill identifier="medical" level="80"/>
-        <RequiredSkill identifier="surgery" level="80"/>
-        <RequiredItem identifier="mannitol"/>
-        <RequiredItem identifier="fpgacircuit"/>
-        <RequiredItem identifier="aluminium"/>
-        <RequiredItem identifier="stabilozine"/>
+      <RequiredSkill identifier="medical" level="80" />
+      <RequiredSkill identifier="surgery" level="80" />
+      <RequiredItem identifier="mannitol" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="aluminium" />
+      <RequiredItem identifier="stabilozine" />
     </Fabricate>
     <Deconstruct time="20">
-        <Item identifier="fpgacircuit" copycondition="true" mincondition="0.1"/>
-        <Item identifier="aluminium" copycondition="true" mincondition="0.1"/>
+      <Item identifier="fpgacircuit" copycondition="true" mincondition="0.1" />
+      <Item identifier="aluminium" copycondition="true" mincondition="0.1" />
     </Deconstruct>
-    
-    <Throwable characterusable="true" slots="Any,RightHand,LeftHand"
-               throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-    </Throwable>
-  
+    <Throwable characterusable="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect"></Throwable>
   </Item>
-
   <!-- triage tag (automatic) -->
-  <Item name="" identifier="triagetag" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,medical" description="" useinhealthinterface="true" scale="0.3"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
+  <Item name="" identifier="triagetag" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="true" scale="0.3" impactsoundtag="impact_metal_light" maxstacksize="8">
     <PreferredContainer primary="medcab" />
-    <Price baseprice="50" soldbydefault="false" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
+    <Price baseprice="50" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="5" amount="2">
-        <RequiredSkill identifier="medical" level="5"/>
-        <RequiredItem identifier="plastic"/>
-      </Fabricate>
-      <Deconstruct time="5"/>
-    <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="256,128,64,128" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/MainAtlas.png" sourcerect="256,128,64,128" depth="0.6" origin="0.5,0.5"/>
-    <Body width="35" height="70" density="5"/>
+      <RequiredSkill identifier="medical" level="5" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <Deconstruct time="5" />
+    <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="256,128,64,128" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/MainAtlas.png" sourcerect="256,128,64,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="5" />
     <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect tags="medical" type="OnUse" target="This"/>
-        <StatusEffect type="OnBroken" target="This">
-          <Remove/>
-        </StatusEffect>
+      <StatusEffect tags="medical" type="OnUse" target="This" />
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
-
   <!-- triage tag (manual) -->
-  <Item name="" identifier="manualtriagetag" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,medical" description="" useinhealthinterface="true" scale="0.3"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
+  <Item name="" identifier="manualtriagetag" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="true" scale="0.3" impactsoundtag="impact_metal_light" maxstacksize="8">
     <PreferredContainer primary="medcab" />
-    <Price baseprice="50" soldbydefault="false" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
+    <Price baseprice="50" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="5" amount="2">
-        <RequiredSkill identifier="medical" level="5"/>
-        <RequiredItem identifier="plastic"/>
-      </Fabricate>
-      <Deconstruct time="5"/>
-    <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="320,128,64,128" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/MainAtlas.png" sourcerect="320,128,64,128" depth="0.6" origin="0.5,0.5"/>
-    <Body width="35" height="70" density="5"/>
+      <RequiredSkill identifier="medical" level="5" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <Deconstruct time="5" />
+    <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="320,128,64,128" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/MainAtlas.png" sourcerect="320,128,64,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="5" />
     <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect tags="medical" type="OnUse" target="This"/>
-        <StatusEffect type="OnBroken" target="This">
-          <Remove/>
-        </StatusEffect>
+      <StatusEffect tags="medical" type="OnUse" target="This" />
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
-
   <Item name="" identifier="surgeonclothes" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,clothing,sterile" scale="0.5" impactsoundtag="impact_soft">
     <PreferredContainer primary="outpostcrewcabinet,abandonedcrewcabinet" minamount="0" maxamount="1" spawnprobability="0.5" />
     <PreferredContainer primary="crewcab" />
     <PreferredContainer secondary="locker" />
-    <Price baseprice="150" soldbydefault="false" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+    <Price baseprice="150" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <Deconstruct time="10" />
     <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sheetindex="7,8" sheetelementsize="64,64" />
     <Sprite name="medicalofficer" texture="Content/Items/Jobgear/MiscJobGear.png" sourcerect="245,149,119,56" depth="0.6" origin="0.5,0.5" />
     <Body width="100" height="50" density="30" friction="0.8" restitution="0.01" />
     <Wearable slots="Any,InnerClothes" msg="ItemMsgPickUpSelect">
-        <sprite name="MedicalOfficer's Uniform Torso" texture="%ModDir%/Images/SurgeonClothes.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Right Hand" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Left Hand" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Left Lower Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Right Lower Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Left Upper Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Right Upper Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Waist" texture="%ModDir%/Images/SurgeonClothes.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Right Thigh" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Left Thigh" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Right Leg" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Left Leg" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Right Shoe" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <sprite name="MedicalOfficer's Uniform Left Shoe" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-        <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="blunttrauma,lacerations,bitewounds" damagemultiplier="0.9" />
+      <sprite name="MedicalOfficer's Uniform Torso" texture="%ModDir%/Images/SurgeonClothes.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Right Hand" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Left Hand" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Left Lower Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Right Lower Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Left Upper Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Right Upper Arm" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Waist" texture="%ModDir%/Images/SurgeonClothes.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Right Thigh" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Left Thigh" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Right Leg" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Left Leg" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Right Shoe" texture="%ModDir%/Images/SurgeonClothes.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="MedicalOfficer's Uniform Left Shoe" texture="%ModDir%/Images/SurgeonClothes.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="blunttrauma,lacerations,bitewounds" damagemultiplier="0.9" />
     </Wearable>
     <ItemContainer capacity="2">
       <Containable items="chem,medical" excludeditems="toolbox,toolbelt" />
     </ItemContainer>
   </Item>
-
   <Item name="" identifier="surgicaldrapes" category="Equipment" tags="smallitem,clothing,sterile" scale="0.5" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft">
-    <Price baseprice="100" soldbydefault="false" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+    <Price baseprice="100" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="50">
       <RequiredSkill identifier="medical" level="15" />
@@ -253,15 +223,14 @@
       <StatusEffect type="OnBroken" target="This">
         <Remove />
       </StatusEffect>
-      <StatusEffect type="OnWearing" target="Character" HideFace="true" ObstructVision="true" LowPassMultiplier="0.2" setvalue="true" disabledeltatime="true"/>
+      <StatusEffect type="OnWearing" target="Character" HideFace="true" ObstructVision="true" LowPassMultiplier="0.2" setvalue="true" disabledeltatime="true" />
       <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="traumaticshock" damagemultiplier="0.5" damagesound="LimbArmor" />
     </Wearable>
     <aitarget maxsightrange="50" />
   </Item>
-
   <Item name="" identifier="surgicalmask" scale="0.5" category="Equipment" Tags="smallitem,clothing,sterile,medical" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_light">
-    <Price baseprice="50" soldbydefault="false" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="16"/>
+    <Price baseprice="50" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="16" />
     </Price>
     <PreferredContainer primary="outpostcrewcabinet,abandonedcrewcabinet" minamount="0" maxamount="1" spawnprobability="0.5" />
     <PreferredContainer primary="crewcab" />
@@ -278,14 +247,14 @@
     <Sprite name="Surgical Mask" texture="%ModDir%/Images/MainAtlas.png" depth="0.55" sourcerect="0,134,64,44" origin="0.5,0.5" />
     <Body width="32" height="20" density="11" />
     <Wearable limbtype="Head" slots="Any,Head" msg="ItemMsgPickUpSelect">
-        <sprite name="Surgical Mask Wearable" texture="%ModDir%/Images/SurgeonClothes.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.5" hidelimb="false" hideotherwearables="false" sourcerect="443,14,60,51" origin="0.25,0.1" /> <!--hidewearablesoftype="moustache,beard"-->
-        <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="bleeding" damagemultiplier="0.8" />
-        <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations" damagemultiplier="0.9" />
+      <sprite name="Surgical Mask Wearable" texture="%ModDir%/Images/SurgeonClothes.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.5" hidelimb="false" hideotherwearables="false" sourcerect="443,14,60,51" origin="0.25,0.1" />
+      <!--hidewearablesoftype="moustache,beard"-->
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="bleeding" damagemultiplier="0.8" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations" damagemultiplier="0.9" />
     </Wearable>
   </Item>
-
   <Item name="" identifier="brainjar" category="Equipment" tags="mediumitem,braincontainer" cargocontaineridentifier="metalcrate" showcontentsintooltip="true" Scale="0.4" fireproof="true" description="" impactsoundtag="impact_soft">
-    <PreferredContainer primary="medcab"/>
+    <PreferredContainer primary="medcab" />
     <Deconstruct time="20">
       <Item identifier="silicon" />
       <Item identifier="steel" />
@@ -295,62 +264,49 @@
       <Item identifier="silicon" />
       <Item identifier="steel" />
     </Fabricate>
-    <Price baseprice="200" soldbydefault="false" >
-    </Price>
+    <Price baseprice="200" soldbydefault="false"></Price>
     <InventoryIcon texture="%ModDir%/Images/MainAtlas.png" sourcerect="0,256,87,128" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Images/MainAtlas.png" depth="0.51" sourcerect="0,256,87,128" origin="0.5,0.5" />
     <Body width="45" height="80" density="15" />
     <Holdable slots="Any,RightHand,LeftHand" holdpos="0,-70" handle1="0,45" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" allowswappingwhenpicked="false" />
     <ItemContainer capacity="1" hideitems="false">
-      <Containable items="braintransplant"/>
+      <Containable items="braintransplant" />
     </ItemContainer>
   </Item>
-
   <Override>
-  <Item name="" identifier="aed" category="Equipment" cargocontaineridentifier="mediccrate"
-        Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
-    <PreferredContainer primary="medcab"/>
-    <Fabricate suitablefabricators="fabricator" requiredtime="60" requiresrecipe="true">
-        <RequiredSkill identifier="electrical" level="80"/>
-        <RequiredSkill identifier="medical" level="70"/>
-        <RequiredItem identifier="plastic"/>
-        <RequiredItem identifier="fpgacircuit"/>
-        <RequiredItem identifier="batterycell"/>
-        <RequiredItem identifier="oxygeniteshard"/>
-    </Fabricate>
-    <Deconstruct time="10">
-        <Item identifier="plastic"/>
-        <Item identifier="fpgacircuit"/>
-    </Deconstruct>
-    <Price baseprice="400" soldbydefault="false">
-    </Price>
-    <InventoryIcon texture="%ModDir:2776270649%/Images/InventoryItemIconAtlas.png" sourcerect="64,0,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir:2776270649%/Images/InGameItemIconAtlas.png" sourcerect="128,0,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="90" height="80" density="20"/>
-    <SuitableTreatment identifier="tachycardia" suitability="60"/>
-    <SuitableTreatment identifier="fibrillation" suitability="60"/>
-    <SuitableTreatment identifier="cardiacarrest" suitability="15"/>
-
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="9.0">
-      <RequiredItems identifier="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired"/>
-
-      <StatusEffect type="OnUse" target="This" Condition="-100"/>
-      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5"
-                    stackable="false"/>
-
-      <StatusEffect type="OnSpawn">
-        <SpawnItem spawnposition="ThisInventory" identifier="batterycell"/>
-      </StatusEffect>
-
-    </MeleeWeapon>
-    <Pickable msg="ItemMsgPickUpSelect"/>
-
-    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
-        <Containable items="mobilebattery"/>
-    </ItemContainer>
-  </Item>
+    <Item name="" identifier="aed" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
+      <PreferredContainer primary="medcab" />
+      <Fabricate suitablefabricators="fabricator" requiredtime="60" requiresrecipe="true">
+        <RequiredSkill identifier="electrical" level="80" />
+        <RequiredSkill identifier="medical" level="70" />
+        <RequiredItem identifier="plastic" />
+        <RequiredItem identifier="fpgacircuit" />
+        <RequiredItem identifier="batterycell" />
+        <RequiredItem identifier="oxygeniteshard" />
+      </Fabricate>
+      <Deconstruct time="10">
+        <Item identifier="plastic" />
+        <Item identifier="fpgacircuit" />
+      </Deconstruct>
+      <Price baseprice="400" soldbydefault="false"></Price>
+      <InventoryIcon texture="%ModDir:2776270649%/Images/InventoryItemIconAtlas.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
+      <Sprite texture="%ModDir:2776270649%/Images/InGameItemIconAtlas.png" sourcerect="128,0,128,128" depth="0.55" origin="0.5,0.5" />
+      <Body width="90" height="80" density="20" />
+      <SuitableTreatment identifier="tachycardia" suitability="60" />
+      <SuitableTreatment identifier="fibrillation" suitability="60" />
+      <SuitableTreatment identifier="cardiacarrest" suitability="15" />
+      <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="9.0">
+        <RequiredItems identifier="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired" />
+        <StatusEffect type="OnUse" target="This" Condition="-100" />
+        <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5" stackable="false" />
+        <StatusEffect type="OnSpawn">
+          <SpawnItem spawnposition="ThisInventory" identifier="batterycell" />
+        </StatusEffect>
+      </MeleeWeapon>
+      <Pickable msg="ItemMsgPickUpSelect" />
+      <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
+        <Containable items="mobilebattery" />
+      </ItemContainer>
+    </Item>
   </Override>
- 
 </Items>

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -1,255 +1,217 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
-
   <!-- /// Gear /// -->
-
-  <Item name="" identifier="defibrillator" category="Equipment" cargocontaineridentifier="mediccrate"
-        Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3"/>
+  <Item name="" identifier="defibrillator" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3" />
     <Fabricate suitablefabricators="fabricator" requiredtime="10">
-        <RequiredSkill identifier="electrical" level="40"/>
-        <RequiredSkill identifier="medical" level="40"/>
-        <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true"/>
-        <RequiredItem identifier="fpgacircuit"/>
-        <RequiredItem identifier="aluminium" mincondition="0.5" usecondition="true"/>
+      <RequiredSkill identifier="electrical" level="40" />
+      <RequiredSkill identifier="medical" level="40" />
+      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="aluminium" mincondition="0.5" usecondition="true" />
     </Fabricate>
     <Deconstruct time="5">
-        <Item identifier="plastic" mincondition="0.1" outcondition="0.5"/>
-        <Item identifier="fpgacircuit" mincondition="0.1"/>
+      <Item identifier="plastic" mincondition="0.1" outcondition="0.5" />
+      <Item identifier="fpgacircuit" mincondition="0.1" />
     </Deconstruct>
     <Price baseprice="100" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,196,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,128,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="90" height="80" density="20"/>
-    <SuitableTreatment identifier="tachycardia" suitability="50"/>
-    <SuitableTreatment identifier="fibrillation" suitability="50"/>
-    <SuitableTreatment identifier="cardiacarrest" suitability="10"/>
-
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="9.0">
-      <RequiredItems identifier="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired"/>
-
-      <StatusEffect type="OnUse" target="This" Condition="-100"/>
-      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5"
-                    stackable="false"/>
-
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,196,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,128,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="90" height="80" density="20" />
+    <SuitableTreatment identifier="tachycardia" suitability="50" />
+    <SuitableTreatment identifier="fibrillation" suitability="50" />
+    <SuitableTreatment identifier="cardiacarrest" suitability="10" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="9.0">
+      <RequiredItems identifier="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired" />
+      <StatusEffect type="OnUse" target="This" Condition="-100" />
+      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5" stackable="false" />
     </MeleeWeapon>
-    <Pickable msg="ItemMsgPickUpSelect"/>
-
+    <Pickable msg="ItemMsgPickUpSelect" />
     <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
-        <Containable items="mobilebattery"/>
+      <Containable items="mobilebattery" />
     </ItemContainer>
   </Item>
-  <Item name="" identifier="aed" category="Equipment" cargocontaineridentifier="mediccrate"
-        Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
-    <PreferredContainer primary="medcab"/>
+  <Item name="" identifier="aed" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
+    <PreferredContainer primary="medcab" />
     <Fabricate suitablefabricators="fabricator" requiredtime="60">
-        <RequiredSkill identifier="electrical" level="80"/>
-        <RequiredSkill identifier="medical" level="70"/>
-        <RequiredItem identifier="plastic"/>
-        <RequiredItem identifier="fpgacircuit"/>
-        <RequiredItem identifier="oxygeniteshard"/>
+      <RequiredSkill identifier="electrical" level="80" />
+      <RequiredSkill identifier="medical" level="70" />
+      <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="oxygeniteshard" />
     </Fabricate>
     <Deconstruct time="5">
-        <Item identifier="plastic"/>
-        <Item identifier="fpgacircuit"/>
+      <Item identifier="plastic" />
+      <Item identifier="fpgacircuit" />
     </Deconstruct>
-    <Price baseprice="400" soldbydefault="false">
-    </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,0,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="128,0,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="90" height="80" density="20"/>
-    <SuitableTreatment identifier="tachycardia" suitability="60"/>
-    <SuitableTreatment identifier="fibrillation" suitability="60"/>
-    <SuitableTreatment identifier="cardiacarrest" suitability="15"/>
-
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="9.0">
-      <RequiredItems identifier="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired"/>
-
-      <StatusEffect type="OnUse" target="This" Condition="-100"/>
-      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5"
-                    stackable="false"/>
-
+    <Price baseprice="400" soldbydefault="false"></Price>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="128,0,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="90" height="80" density="20" />
+    <SuitableTreatment identifier="tachycardia" suitability="60" />
+    <SuitableTreatment identifier="fibrillation" suitability="60" />
+    <SuitableTreatment identifier="cardiacarrest" suitability="15" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="9.0">
+      <RequiredItems identifier="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired" />
+      <StatusEffect type="OnUse" target="This" Condition="-100" />
+      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5" stackable="false" />
     </MeleeWeapon>
-    <Pickable msg="ItemMsgPickUpSelect"/>
-
+    <Pickable msg="ItemMsgPickUpSelect" />
     <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
-        <Containable items="mobilebattery"/>
+      <Containable items="mobilebattery" />
     </ItemContainer>
   </Item>
-  
-  <Item name="" identifier="bvm" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.370">
-        <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3"/>
-        <Fabricate suitablefabricators="fabricator" requiredtime="10">
-            <RequiredSkill identifier="medical" level="30"/>
-            <RequiredItem identifier="plastic"/>
-        </Fabricate>
-        <Deconstruct time="5">
-            <Item identifier="plastic" outcondition="0.5"/>
-        </Deconstruct>
-        <Price baseprice="100" soldbydefault="false">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9"/>
-        </Price>
-
-        <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,64,64,64"
-                       origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="512,0,128,128" depth="0.55"
-                origin="0.5,0.5"/>
-        <Body width="90" height="80" density="20"/>
-        <SuitableTreatment identifier="oxygenlow" suitability="50"/>
-
-        <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
-          <RequiredItems identifier="weldingtoolfuel,oxygensource,paint" type="Contained" msg="ItemMsgOxygenTankRequired"/>
-          <StatusEffect type="OnUse" target="UseTarget">
-              <Sound file="%ModDir%/Sound/pump.ogg" range="500"/>
-              <Conditional IsDead="false"/>
-              <ReduceAffliction identifier="oxygenlow" amount="10" />
-          </StatusEffect>
-          <StatusEffect type="OnUse" target="This" Condition="-100"/>
-          <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="1"
-                        stackable="false"/>
-          <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-2" comparison="and">
-              <Conditional IsDead="false"/>
-              <ReduceAffliction identifier="oxygenlow" amount="90" />
-              <RequiredItem items="oxygentank" type="Contained"/>
-          </StatusEffect>
-          <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-2" comparison="and">
-              <Conditional IsDead="false"/>
-              <ReduceAffliction identifier="oxygenlow" amount="90" />
-              <ReduceAffliction identifier="respiratoryarrest" amount="100" />
-              <RequiredItem items="oxygenitetank" type="Contained"/>
-          </StatusEffect>
-          <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-5" comparison="and">
-              <Conditional IsDead="false"/>
-              <Affliction identifier="oxygenlow" amount="110" />
-              <Affliction identifier="lungdamage" amount="10" />
-              <!-- We do a little trolling  -->
-              <RequiredItem items="weldingfueltank" type="Contained"/>
-          </StatusEffect>
-                <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-7" comparison="and">
-              <Conditional IsDead="false"/>
-              <Affliction identifier="oxygenlow" amount="110" />
-              <Affliction identifier="lungdamage" amount="20" />
-              <Affliction identifier="burn" amount="10" />
-              <RequiredItem items="incendiumfueltank" type="Contained"/>
-          </StatusEffect>
-          <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-5" comparison="and">
-              <Conditional IsDead="false"/>
-              <Affliction identifier="oxygenlow" amount="50" />
-              <Affliction identifier="chemaddiction" amount="5" />
-              <ReduceAffliction identifier="chemwithdrawal" amount="20" />
-              <Affliction identifier="lungdamage" amount="3" />
-              <!-- Huff paint -->
-              <RequiredItem items="paint" type="Contained"/>
-          </StatusEffect>
-        </MeleeWeapon>
-        <Pickable msg="ItemMsgPickUpSelect"/>
-        <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="tank">
-            <Containable items="weldingtoolfuel,oxygensource,paint"/>
-        </ItemContainer>
-    </Item>
-  <Item name="" identifier="autocpr" category="Equipment" tags="smallitem,clothing,medical" scale="0.40"
-          cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft">
-    <Upgrade gameversion="0.9.3.0" scale="0.40"/>
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.25"/>
+  <Item name="" identifier="bvm" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.370">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="medical" level="30" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <Deconstruct time="5">
+      <Item identifier="plastic" outcondition="0.5" />
+    </Deconstruct>
+    <Price baseprice="100" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" />
+    </Price>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="512,0,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="90" height="80" density="20" />
+    <SuitableTreatment identifier="oxygenlow" suitability="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
+      <RequiredItems identifier="weldingtoolfuel,oxygensource,paint" type="Contained" msg="ItemMsgOxygenTankRequired" />
+      <StatusEffect type="OnUse" target="UseTarget">
+        <Sound file="%ModDir%/Sound/pump.ogg" range="500" />
+        <Conditional IsDead="false" />
+        <ReduceAffliction identifier="oxygenlow" amount="10" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This" Condition="-100" />
+      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="1" stackable="false" />
+      <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-2" comparison="and">
+        <Conditional IsDead="false" />
+        <ReduceAffliction identifier="oxygenlow" amount="90" />
+        <RequiredItem items="oxygentank" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-2" comparison="and">
+        <Conditional IsDead="false" />
+        <ReduceAffliction identifier="oxygenlow" amount="90" />
+        <ReduceAffliction identifier="respiratoryarrest" amount="100" />
+        <RequiredItem items="oxygenitetank" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-5" comparison="and">
+        <Conditional IsDead="false" />
+        <Affliction identifier="oxygenlow" amount="110" />
+        <Affliction identifier="lungdamage" amount="10" />
+        <!-- We do a little trolling  -->
+        <RequiredItem items="weldingfueltank" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-7" comparison="and">
+        <Conditional IsDead="false" />
+        <Affliction identifier="oxygenlow" amount="110" />
+        <Affliction identifier="lungdamage" amount="20" />
+        <Affliction identifier="burn" amount="10" />
+        <RequiredItem items="incendiumfueltank" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained,UseTarget" Condition="-5" comparison="and">
+        <Conditional IsDead="false" />
+        <Affliction identifier="oxygenlow" amount="50" />
+        <Affliction identifier="chemaddiction" amount="5" />
+        <ReduceAffliction identifier="chemwithdrawal" amount="20" />
+        <Affliction identifier="lungdamage" amount="3" />
+        <!-- Huff paint -->
+        <RequiredItem items="paint" type="Contained" />
+      </StatusEffect>
+    </MeleeWeapon>
+    <Pickable msg="ItemMsgPickUpSelect" />
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="tank">
+      <Containable items="weldingtoolfuel,oxygensource,paint" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="autocpr" category="Equipment" tags="smallitem,clothing,medical" scale="0.40" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft">
+    <Upgrade gameversion="0.9.3.0" scale="0.40" />
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.25" />
     <Price baseprice="300" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" />
     </Price>
     <Deconstruct time="10">
-      <Item identifier="plastic" outcondition="0.5"/>
-      <Item identifier="steel" outcondition="0.5"/>
+      <Item identifier="plastic" outcondition="0.5" />
+      <Item identifier="steel" outcondition="0.5" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="30">
-      <RequiredSkill identifier="medical" level="40"/>
-      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true"/>
-      <RequiredItem identifier="fpgacircuit"/>
-      <RequiredItem identifier="steel" mincondition="0.5" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="40" />
+      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="steel" mincondition="0.5" usecondition="true" />
     </Fabricate>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,64,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="640,0,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body radius="45" height="50" density="40"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="640,0,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body radius="45" height="50" density="40" />
     <Wearable slots="Any,OuterClothes" msg="ItemMsgPickUpSelect">
-      <StatusEffect type="OnWearing" target="This" Condition="-100" disabledeltatime="true" delay="0.3"
-                    stackable="false">
-        <Condition Condition="gte 99"/>
+      <StatusEffect type="OnWearing" target="This" Condition="-100" disabledeltatime="true" delay="0.3" stackable="false">
+        <Condition Condition="gte 99" />
       </StatusEffect>
-      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="3"
-                    stackable="false"/>
+      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="3" stackable="false" />
       <StatusEffect type="OnWearing" target="Contained,Character,This" Condition="-0.2" comparison="And">
-        <Conditional IsDead="false"/>
-        <RequiredItem items="batterycell" type="Contained"/>
+        <Conditional IsDead="false" />
+        <RequiredItem items="batterycell" type="Contained" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Contained,Character,This" Condition="-0.1" comparison="And">
-        <Conditional IsDead="false"/>
-        <RequiredItem items="fulguriumbatterycell" type="Contained"/>
+        <Conditional IsDead="false" />
+        <RequiredItem items="fulguriumbatterycell" type="Contained" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Character,This" comparison="Or" disabledeltatime="true">
-        <Conditional IsDead="false"/>
-        <RequiredItem items="mobilebattery" type="Contained"/>
+        <Conditional IsDead="false" />
+        <RequiredItem items="mobilebattery" type="Contained" />
         <Affliction identifier="cpr_buff_auto" amount="10" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Character,This" comparison="And">
-        <Conditional IsDead="false" Condition="gte 99"/>
-        <RequiredItem items="mobilebattery" type="Contained"/>
-        <Sound file="%ModDir%/Sound/pump.ogg" range="500"/>
+        <Conditional IsDead="false" Condition="gte 99" />
+        <RequiredItem items="mobilebattery" type="Contained" />
+        <Sound file="%ModDir%/Sound/pump.ogg" range="500" />
       </StatusEffect>
-      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="cpr_buff" damagemultiplier="0.0"
-                      damagesound="LimbArmor"/>
-      <sprite name="AutoPulse" texture="%ModDir%/Images/InGameItemIconAtlas.png" limb="Torso"
-              scale="0.8" hidelimb="false" inherittexturescale="true" sourcerect="640,0,128,128"
-              origin="0.5,0.6"/>
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="cpr_buff" damagemultiplier="0.0" damagesound="LimbArmor" />
+      <sprite name="AutoPulse" texture="%ModDir%/Images/InGameItemIconAtlas.png" limb="Torso" scale="0.8" hidelimb="false" inherittexturescale="true" sourcerect="640,0,128,128" origin="0.5,0.6" />
     </Wearable>
     <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
-      <Containable items="mobilebattery"/>
+      <Containable items="mobilebattery" />
     </ItemContainer>
   </Item>
-  <Item name="" identifier="traumashears" category="Equipment" cargocontaineridentifier="mediccrate"
-        Tags="smallitem,medical,surgerytool" description="" useinhealthinterface="True" scale="0.5">
-      <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-      <PreferredContainer primary="locker"/>
-      <Fabricate suitablefabricators="fabricator">
-        <RequiredSkill identifier="medical" level="10"/>
-        <RequiredSkill identifier="mechanical" level="10"/>
-          <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-          <RequiredItem identifier="plastic" mincondition="0.25" usecondition="true"/>
-      </Fabricate>
-      <Deconstruct time="5">
-          <Item identifier="plastic" outcondition="0.25"/>
-      </Deconstruct>
-      <Price baseprice="50" soldbydefault="true">
-          <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9"/>
-      </Price>
-      <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,192,64,64"
-                      origin="0.5,0.5"/>
-      <Sprite texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,192,64,64"
-              depth="0.55" origin="0.5,0.5"/>
-      <Body width="60" height="55" density="50"/>
-      <SuitableTreatment identifier="dirtybandage" suitability="100"/>
-      <SuitableTreatment identifier="bandaged" suitability="100"/>
-      <SuitableTreatment identifier="gypsumcast" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_green" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_yellow" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_red" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_black" suitability="100"/>
-      <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="10,-10" holdangle="210" reload="1.0">
-          <StatusEffect type="OnUse" target="Limb" comparison="and"/>
-      </MeleeWeapon>
+  <Item name="" identifier="traumashears" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgerytool" description="" useinhealthinterface="True" scale="0.5">
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
+    <Fabricate suitablefabricators="fabricator">
+      <RequiredSkill identifier="medical" level="10" />
+      <RequiredSkill identifier="mechanical" level="10" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="plastic" mincondition="0.25" usecondition="true" />
+    </Fabricate>
+    <Deconstruct time="5">
+      <Item identifier="plastic" outcondition="0.25" />
+    </Deconstruct>
+    <Price baseprice="50" soldbydefault="true">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" />
+    </Price>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,192,64,64" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="55" density="50" />
+    <SuitableTreatment identifier="dirtybandage" suitability="100" />
+    <SuitableTreatment identifier="bandaged" suitability="100" />
+    <SuitableTreatment identifier="gypsumcast" suitability="100" />
+    <SuitableTreatment identifier="triagetag_green" suitability="100" />
+    <SuitableTreatment identifier="triagetag_yellow" suitability="100" />
+    <SuitableTreatment identifier="triagetag_red" suitability="100" />
+    <SuitableTreatment identifier="triagetag_black" suitability="100" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="10,-10" holdangle="210" reload="1.0">
+      <StatusEffect type="OnUse" target="Limb" comparison="and" />
+    </MeleeWeapon>
   </Item>
-
   <Item name="" identifier="wheelchair" category="Equipment" tags="provocative,mediumitem" scale="0.5" fireproof="false" description="" cargocontaineridentifier="mediccrate" impactsoundtag="impact_metal_heavy">
     <Price baseprice="100" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="20">
       <RequiredSkill identifier="medical" level="20" />
@@ -265,70 +227,60 @@
     <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,768,256,256" depth="0.55" origin="0.5,0.5" />
     <Body radius="60" width="60" density="15" />
     <Wearable slots="Any,OuterClothes" msg="ItemMsgEquipSelect" autoequipwhenfull="true">
-      <sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" limb="Waist" hidelimb="false" inherittexturescale="true" hideotherwearables="false" inheritorigin="false" sourcerect="0,768,256,256" inheritlimbdepth="false" depth="-0.1" /> <!-- depth="0.11504" -->
+      <sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" limb="Waist" hidelimb="false" inherittexturescale="true" hideotherwearables="false" inheritorigin="false" sourcerect="0,768,256,256" inheritlimbdepth="false" depth="-0.1" />
+      <!-- depth="0.11504" -->
     </Wearable>
-
     <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true">
-      <limbposition limb="Head" position="-6,-10" allowusinglimb="true"/>
-      <limbposition limb="Torso" position="104,0" allowusinglimb="true"/>
-      <limbposition limb="Waist" position="244,-80" allowusinglimb="true"/>
-      <limbposition limb="RightFoot" position="380,-20" allowusinglimb="true"/>
-      <limbposition limb="LeftFoot" position="380,-20" allowusinglimb="true"/>
-      <limbposition limb="RightHand" position="234,-10" allowusinglimb="false"/>
-      <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false"/>
+      <limbposition limb="Head" position="-6,-10" allowusinglimb="true" />
+      <limbposition limb="Torso" position="104,0" allowusinglimb="true" />
+      <limbposition limb="Waist" position="244,-80" allowusinglimb="true" />
+      <limbposition limb="RightFoot" position="380,-20" allowusinglimb="true" />
+      <limbposition limb="LeftFoot" position="380,-20" allowusinglimb="true" />
+      <limbposition limb="RightHand" position="234,-10" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false" />
     </Controller>
     <aitarget maxsightrange="50" />
   </Item>
-  
-  
   <!-- /// Surgery /// -->
-
-  <Item name="" identifier="operatingtable" scale="0.4" Tags="" maxstacksize="1" category="medical"
-        description="" isshootable="true">
-    <Upgrade gameversion="0.12.0.0" noninteractable="false"/>
-    <Body width="416" height="192" density="40"/>
+  <Item name="" identifier="operatingtable" scale="0.4" Tags="" maxstacksize="1" category="medical" description="" isshootable="true">
+    <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+    <Body width="416" height="192" density="40" />
     <Price baseprice="200" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
     <Deconstruct time="40">
-      <Item identifier="steel"/>
-      <Item identifier="aluminium"/>
+      <Item identifier="steel" />
+      <Item identifier="aluminium" />
     </Deconstruct>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="30">
-      <RequiredSkill identifier="medical" level="50"/>
-      <RequiredItem identifier="fpgacircuit"/>
-      <RequiredItem identifier="plastic"/>
-      <RequiredItem identifier="steel"/>
-      <RequiredItem identifier="aluminium"/>
+      <RequiredSkill identifier="medical" level="50" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="steel" />
+      <RequiredItem identifier="aluminium" />
     </Fabricate>
-    <InventoryIcon texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192"
-                   origin="0.5,0.5"/>
-    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.75"
-            premultiplyalpha="false" origin="0.5,0.5"/>
-    <Holdable selectkey="Action" pickkey="Use" slots="RightHand+LeftHand" msg="ItemMsgDetach" PickingTime="5"
-              aimpos="85,-10" handle1="0,0" attachable="true" aimable="true">
+    <InventoryIcon texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" origin="0.5,0.5" />
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.75" premultiplyalpha="false" origin="0.5,0.5" />
+    <Holdable selectkey="Action" pickkey="Use" slots="RightHand+LeftHand" msg="ItemMsgDetach" PickingTime="5" aimpos="85,-10" handle1="0,0" attachable="true" aimable="true">
       <StatusEffect type="OnNotContained" target="NearbyCharacters" range="200" stackable="true">
-        <Affliction identifier="table" amount="2"/>
-        <Affliction identifier="alv" amount="10"/>
+        <Affliction identifier="table" amount="2" />
+        <Affliction identifier="alv" amount="10" />
       </StatusEffect>
       <StatusEffect type="Always" target="NearbyCharacters" range="200" delay="1" stackable="false">
         <LuaHook name="surgerytable.update" />
       </StatusEffect>
     </Holdable>
-    <LightComponent range="10.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false"
-                    allowingameediting="false">
-      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" depth="0.025" sourcerect="96,304,416,192"
-              origin="0.5,0.5" alpha="1.0"/>
+    <LightComponent range="10.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" depth="0.025" sourcerect="96,304,416,192" origin="0.5,0.5" alpha="1.0" />
     </LightComponent>
     <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true">
-      <limbposition limb="Head" position="-6,-10" allowusinglimb="true"/>
-      <limbposition limb="Torso" position="104,0" allowusinglimb="true"/>
-      <limbposition limb="Waist" position="244,-80" allowusinglimb="true"/>
-      <limbposition limb="RightFoot" position="380,-20" allowusinglimb="true"/>
-      <limbposition limb="LeftFoot" position="380,-20" allowusinglimb="true"/>
-      <limbposition limb="RightHand" position="234,-10" allowusinglimb="false"/>
-      <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false"/>
-      
+      <limbposition limb="Head" position="-6,-10" allowusinglimb="true" />
+      <limbposition limb="Torso" position="104,0" allowusinglimb="true" />
+      <limbposition limb="Waist" position="244,-80" allowusinglimb="true" />
+      <limbposition limb="RightFoot" position="380,-20" allowusinglimb="true" />
+      <limbposition limb="LeftFoot" position="380,-20" allowusinglimb="true" />
+      <limbposition limb="RightHand" position="234,-10" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false" />
       <!--
       <StatusEffect type="Always" target="NearbyCharacters" range="100">
         <Conditional sym_unconsciousness="gt 0.1"/>
@@ -337,10 +289,11 @@
       -->
     </Controller>
     <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
-      <GuiFrame relativesize="0.15,0.6" minsize="300,450" maxsize="380,500" anchor="Center" style="ConnectionPanel" />      <RequiredItem items="screwdriver" type="Equipped" />
+      <GuiFrame relativesize="0.15,0.6" minsize="300,450" maxsize="380,500" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
       <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
-      <output name="alive_out" displayname="connection.aliveout"/>
-      <output name="conscious_out" displayname="connection.consciousout"/>
+      <output name="alive_out" displayname="connection.aliveout" />
+      <output name="conscious_out" displayname="connection.consciousout" />
       <output name="name_out" displayname="connection.nameout" />
       <output name="vitality_out" displayname="connection.vitalityout" />
       <output name="heartrate_out" displayname="connection.heartrateout" />
@@ -354,1020 +307,880 @@
       <output name="bloodph_out" displayname="connection.bloodphout" />
     </ConnectionPanel>
   </Item>
-
-  <Item name="" identifier="advscalpel" category="Equipment" cargocontaineridentifier="mediccrate"
-        Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-      <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-      <PreferredContainer primary="locker"/>
-      <Fabricate suitablefabricators="fabricator">
-        <RequiredSkill identifier="medical" level="20"/>
-        <RequiredSkill identifier="mechanical" level="15"/>
-          <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-          <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
-      </Fabricate>
-      <Deconstruct>
-          <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
-      </Deconstruct>
-      <Price baseprice="35" soldbydefault="true">
-          <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
-      </Price>
-      <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,0,64,64"
-                      origin="0.5,0.5"/>
-      <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,188,122,8"
-              depth="0.55" origin="0.5,0.5"/>
-      <Body width="65" height="15" density="50"/>
-      <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
-          <StatusEffect type="OnUse" target="Limb" comparison="and">
-            <Conditional analgesia="gte 1"/>
-            <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500"/>
-            <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500"/>
-            <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500"/>
-            <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500"/>
-            <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500"/>
-            <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500"/>
-          </StatusEffect>
-      </MeleeWeapon>
-  </Item>
-  <Item name="" identifier="advhemostat" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-        <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-        <PreferredContainer primary="locker"/>
-        <Fabricate suitablefabricators="fabricator">
-          <RequiredSkill identifier="medical" level="20"/>
-        <RequiredSkill identifier="mechanical" level="15"/>
-            <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-            <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
-        </Fabricate>
-        <Deconstruct>
-            <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
-        </Deconstruct>
-        <Price baseprice="35" soldbydefault="true">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
-        </Price>
-        <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="192,0,64,64"
-                       origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="384,0,128,128" depth="0.55"
-                origin="0.5,0.5"/>
-        <Body width="120" height="110" density="50"/>
-        <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,-5" holdangle="-90" reload="1.0">
-
-        </MeleeWeapon>
-    </Item>
-  <Item name="" identifier="advretractors" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.2">
-    <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="advscalpel" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="20"/>
-      <RequiredSkill identifier="mechanical" level="15"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="20" />
+      <RequiredSkill identifier="mechanical" level="15" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="35" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,0,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,128,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="120" height="110" density="50"/>
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,-5" holdangle="-90" reload="1.0">
-
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,188,122,8" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="15" density="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
+      <StatusEffect type="OnUse" target="Limb" comparison="and">
+        <Conditional analgesia="gte 1" />
+        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="surgicaldrill" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="advhemostat" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="30"/>
-      <RequiredSkill identifier="mechanical" level="30"/>
-        <RequiredItem identifier="steel" mincondition="0.5" usecondition="true"/>
-        <RequiredItem identifier="zinc" mincondition="0.5" usecondition="true"/>
-        <RequiredItem identifier="fpgacircuit"/>
+      <RequiredSkill identifier="medical" level="20" />
+      <RequiredSkill identifier="mechanical" level="15" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-        <Item identifier="steel" outcondition="0.5"/>
-        <Item identifier="zinc" outcondition="0.5"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
+    </Deconstruct>
+    <Price baseprice="35" soldbydefault="true">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="192,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="384,0,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="120" height="110" density="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,-5" holdangle="-90" reload="1.0"></MeleeWeapon>
+  </Item>
+  <Item name="" identifier="advretractors" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.2">
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
+    <Fabricate suitablefabricators="fabricator">
+      <RequiredSkill identifier="medical" level="20" />
+      <RequiredSkill identifier="mechanical" level="15" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
+    </Fabricate>
+    <Deconstruct>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
+    </Deconstruct>
+    <Price baseprice="35" soldbydefault="true">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,128,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="120" height="110" density="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,-5" holdangle="-90" reload="1.0"></MeleeWeapon>
+  </Item>
+  <Item name="" identifier="surgicaldrill" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
+    <Fabricate suitablefabricators="fabricator">
+      <RequiredSkill identifier="medical" level="30" />
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="steel" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="fpgacircuit" />
+    </Fabricate>
+    <Deconstruct>
+      <Item identifier="steel" outcondition="0.5" />
+      <Item identifier="zinc" outcondition="0.5" />
     </Deconstruct>
     <Price baseprice="80" soldbydefault="true">
-        <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,0,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="256,0,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="120" height="100" density="50"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="256,0,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="120" height="100" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,-5" holdangle="-20" reload="1.0">
       <StatusEffect type="OnUse" target="Limb" comparison="and">
-          <Conditional analgesia="gte 1"/>
-          <Sound file="%ModDir%/Sound/drill.ogg" range="500"/>
+        <Conditional analgesia="gte 1" />
+        <Sound file="%ModDir%/Sound/drill.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="surgerysaw" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery" description="" useinhealthinterface="True" scale="0.4">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.5"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="surgerysaw" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery" description="" useinhealthinterface="True" scale="0.4">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.5" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="30"/>
-      <RequiredSkill identifier="mechanical" level="30"/>
-      <RequiredItem identifier="titaniumaluminiumalloy" mincondition="0.5" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="30" />
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="titaniumaluminiumalloy" mincondition="0.5" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="aluminium" outcondition="0.5"/>
+      <Item identifier="aluminium" outcondition="0.5" />
     </Deconstruct>
     <Price baseprice="100" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,64,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,0,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="120" height="50" density="50"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,0,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="120" height="50" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-18,-7" holdangle="90" reload="1.0">
       <StatusEffect type="OnUse" target="Limb" comparison="And">
-        <Conditional analgesia="gte 1"/>
-        <Conditional retractedskin="gte 99"/>
-        <sound file="%ModDir%/Sound/bonebreak4.ogg" selectionmode="random" range="500"/>
-        <sound file="%ModDir%/Sound/bonebreak3.ogg" range="500"/>
-        <sound file="%ModDir%/Sound/bonebreak2.ogg" range="500"/>
-        <sound file="%ModDir%/Sound/bonebreak1.ogg" range="500"/>
+        <Conditional analgesia="gte 1" />
+        <Conditional retractedskin="gte 99" />
+        <sound file="%ModDir%/Sound/bonebreak4.ogg" selectionmode="random" range="500" />
+        <sound file="%ModDir%/Sound/bonebreak3.ogg" range="500" />
+        <sound file="%ModDir%/Sound/bonebreak2.ogg" range="500" />
+        <sound file="%ModDir%/Sound/bonebreak1.ogg" range="500" />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="tweezers" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.150">
-    <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="tweezers" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.150">
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="30"/>
-      <RequiredSkill identifier="mechanical" level="30"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="30" />
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="35" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,0,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,256,128,128" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="65" height="65" density="50"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="0,256,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="65" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,-5" holdangle="10" reload="1.0">
       <StatusEffect type="OnUse" target="Limb" comparison="And" disabledeltatime="True">
-        <Sound file="%ModDir%/Sound/squelch1.ogg"/>
+        <Sound file="%ModDir%/Sound/squelch1.ogg" />
       </StatusEffect>
-
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="endovascballoon" category="Equipment" maxstacksize="1" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool"
-          description=""
-          useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
+  <Item name="" identifier="endovascballoon" category="Equipment" maxstacksize="1" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5" />
     <Fabricate suitablefabricators="medicalfabricator" amount="1">
-      <RequiredSkill identifier="medical" level="25"/>
-      <RequiredItem identifier="organicfiber" mincondition="0.5" usecondition="true"/>
-      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true"/>
-      <RequiredItem identifier="rubber" mincondition="0.5" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="25" />
+      <RequiredItem identifier="organicfiber" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="rubber" mincondition="0.5" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="plastic" outcondition="0.5"/>
-      <Item identifier="rubber" outcondition="0.5"/>
+      <Item identifier="plastic" outcondition="0.5" />
+      <Item identifier="rubber" outcondition="0.5" />
     </Deconstruct>
     <Price baseprice="30" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="192,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="512,256,128,128"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="100" height="100" density="50"/>
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="192,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="512,256,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="100" height="100" density="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
       <StatusEffect type="OnUse" target="This">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="medstent" category="Equipment" maxstacksize="1" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,syringe,surgerytool"
-          description=""
-          useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
+  <Item name="" identifier="medstent" category="Equipment" maxstacksize="1" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,syringe,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5" />
     <Fabricate suitablefabricators="medicalfabricator" amount="1">
-      <RequiredSkill identifier="medical" level="25"/>
-      <RequiredItem identifier="organicfiber" mincondition="0.5" usecondition="true"/>
-      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true"/>
-      <RequiredItem identifier="rubber" mincondition="0.5" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="25" />
+      <RequiredItem identifier="organicfiber" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true" />
+      <RequiredItem identifier="rubber" mincondition="0.5" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="plastic" outcondition="0.5"/>
-      <Item identifier="rubber" outcondition="0.5"/>
+      <Item identifier="plastic" outcondition="0.5" />
+      <Item identifier="rubber" outcondition="0.5" />
     </Deconstruct>
     <Price baseprice="70" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,128,64,64"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="100" height="100" density="50"/>
-    <SuitableTreatment identifier="arterialcut5" suitability="50"/>
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,128,64,64" depth="0.55" origin="0.5,0.5" />
+    <Body width="100" height="100" density="50" />
+    <SuitableTreatment identifier="arterialcut5" suitability="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
       <StatusEffect type="OnUse" target="This" condition="-100">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="drainage" category="Equipment" maxstacksize="1"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,syringe,surgerytool"
-          description=""
-          useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
+  <Item name="" identifier="drainage" category="Equipment" maxstacksize="1" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,syringe,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5" />
     <Fabricate suitablefabricators="medicalfabricator" amount="1">
-      <RequiredSkill identifier="medical" level="25"/>
-      <RequiredItem identifier="plastic"/>
+      <RequiredSkill identifier="medical" level="25" />
+      <RequiredItem identifier="plastic" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="plastic" outcondition="0.5"/>
+      <Item identifier="plastic" outcondition="0.5" />
     </Deconstruct>
     <Price baseprice="25" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,256,128,128"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="100" height="100" density="50"/>
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
-      <RequiredSkill identifier="medical" level="30"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,256,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="100" height="100" density="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
+      <RequiredSkill identifier="medical" level="30" />
       <StatusEffect type="OnUse" target="This">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
-  <Item name="" identifier="organscalpel_liver" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="organscalpel_liver" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="35"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="35" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="35" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="65" height="15" density="50"/>
-    
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="15" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
       <!-- extracting organ -->
       <StatusEffect tags="medical" type="OnUse" target="This,Limb" comparison="and" disabledeltatime="true">
-        <Conditional retractedskin="gte 1"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500"/>
+        <Conditional retractedskin="gte 1" />
+        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
       </StatusEffect>
     </MeleeWeapon>
-  
   </Item>
-  <Item name="" identifier="organscalpel_kidneys" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="organscalpel_kidneys" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="35"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="35" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="35" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="65" height="15" density="50"/>
-    
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="15" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
       <!-- extracting organ -->
       <StatusEffect tags="medical" type="OnUse" target="This,Limb" comparison="and" disabledeltatime="true">
-        <Conditional retractedskin="gte 1"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500"/>
+        <Conditional retractedskin="gte 1" />
+        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
       </StatusEffect>
     </MeleeWeapon>
-  
   </Item>
-  <Item name="" identifier="organscalpel_lungs" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="organscalpel_lungs" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="35"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="35" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="35" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="65" height="15" density="50"/>
-    
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="15" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
       <!-- extracting organ -->
       <StatusEffect tags="medical" type="OnUse" target="This,Limb" comparison="and" disabledeltatime="true">
-        <Conditional retractedskin="gte 1"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500"/>
+        <Conditional retractedskin="gte 1" />
+        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
       </StatusEffect>
     </MeleeWeapon>
-  
   </Item>
-  <Item name="" identifier="organscalpel_heart" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="organscalpel_heart" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="35"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="35" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="35" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="65" height="15" density="50"/>
-    
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="15" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
       <!-- extracting organ -->
       <StatusEffect tags="medical" type="OnUse" target="This,Limb" comparison="and" disabledeltatime="true">
-        <Conditional retractedskin="gte 1"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500"/>
+        <Conditional retractedskin="gte 1" />
+        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
       </StatusEffect>
     </MeleeWeapon>
-  
   </Item>
-  <Item name="" identifier="organscalpel_brain" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer"/>
-    <PreferredContainer primary="locker"/>
+  <Item name="" identifier="organscalpel_brain" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="60"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="oxygeniteshard"/>
-      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="60" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="steel" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="oxygeniteshard" />
+      <RequiredItem identifier="zinc" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <Item identifier="steel"/>
-      <Item identifier="zinc" mincondition="0.1" outcondition="0.25"/>
+      <Item identifier="steel" />
+      <Item identifier="zinc" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="200" soldbydefault="true">
-      <Price locationtype="research" multiplier="1" sold="true" minavailable="1"/>
+      <Price locationtype="research" multiplier="1" sold="true" minavailable="1" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="65" height="15" density="50"/>
-    
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="131,203,122,8" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="15" density="50" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-7,-5" holdangle="60" reload="1.0">
       <!-- extracting organ -->
       <StatusEffect tags="medical" type="OnUse" target="This,Limb" comparison="and" disabledeltatime="true">
-        <Conditional retractedskin="gte 1"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500"/>
-        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500"/>
+        <Conditional retractedskin="gte 1" />
+        <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+        <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
       </StatusEffect>
     </MeleeWeapon>
-  
   </Item>
-
-
-  <Item name="" identifier="osteosynthesisimplants" category="Equipment" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery" description="" useinhealthinterface="True" scale="0.4">
+  <Item name="" identifier="osteosynthesisimplants" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery" description="" useinhealthinterface="True" scale="0.4">
     <Price baseprice="200" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <PreferredContainer primary="toxcontainer" spawnprobability="1"/>
-    <PreferredContainer primary="locker"/>
+    <PreferredContainer primary="toxcontainer" spawnprobability="1" />
+    <PreferredContainer primary="locker" />
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="35"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="titaniumaluminiumalloy"/>
-      <RequiredItem identifier="liquidoxygenite"/>
-      <RequiredItem identifier="calcium"/>
+      <RequiredSkill identifier="medical" level="35" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="titaniumaluminiumalloy" />
+      <RequiredItem identifier="liquidoxygenite" />
+      <RequiredItem identifier="calcium" />
     </Fabricate>
     <Deconstruct time="10">
-      <Item identifier="titaniumaluminiumalloy" copycondition="true" mincondition="0.1"/>
-      <Item identifier="calcium" copycondition="true" mincondition="0.1"/>
+      <Item identifier="titaniumaluminiumalloy" copycondition="true" mincondition="0.1" />
+      <Item identifier="calcium" copycondition="true" mincondition="0.1" />
     </Deconstruct>
     <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="87,403,84,67" origin="0.5,0.5" depth="0.6" />
-    <Body width="65" height="15" density="50"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
+    <Body width="65" height="15" density="50" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
       <StatusEffect type="OnUse" target="Limb, this" comparison="and">
-        <Conditional drilledbones="gte 99"/>
-        <Conditional analgesia="gte 1"/>
-        <Sound file="%ModDir%/Sound/drill.ogg" range="500"/>
+        <Conditional drilledbones="gte 99" />
+        <Conditional analgesia="gte 1" />
+        <Sound file="%ModDir%/Sound/drill.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
-      </StatusEffect>  
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
-  <Item name="" identifier="spinalimplant" description="" scale="0.3" useinhealthinterface="True"
-    Tags="smallitem,medical,surgery">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.5"/>
+  <Item name="" identifier="spinalimplant" description="" scale="0.3" useinhealthinterface="True" Tags="smallitem,medical,surgery">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.5" />
     <Price baseprice="200" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
     <Fabricate suitablefabricators="fabricator">
-      <RequiredSkill identifier="medical" level="70"/>
-      <RequiredSkill identifier="mechanical" level="20"/>
-      <RequiredItem identifier="titaniumaluminiumalloy"/>
-      <RequiredItem identifier="liquidoxygenite"/>
-      <RequiredItem identifier="calcium"/>
+      <RequiredSkill identifier="medical" level="70" />
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="titaniumaluminiumalloy" />
+      <RequiredItem identifier="liquidoxygenite" />
+      <RequiredItem identifier="calcium" />
     </Fabricate>
     <Deconstruct time="10">
-      <Item identifier="titaniumaluminiumalloy" copycondition="true" mincondition="0.1"/>
-      <Item identifier="calcium" copycondition="true" mincondition="0.1"/>
+      <Item identifier="titaniumaluminiumalloy" copycondition="true" mincondition="0.1" />
+      <Item identifier="calcium" copycondition="true" mincondition="0.1" />
     </Deconstruct>
     <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="344,403,84,67" origin="0.5,0.5" depth="0.6" />
-    <Body width="60" height="90" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,5"
-                  handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+    <Body width="60" height="90" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnUse" target="Limb, This" disabledeltatime="true" comparison="And">
-        <Conditional retractedskin="gt 50"/>
+        <Conditional retractedskin="gt 50" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
-  <Item name="" identifier="suture" category="Equipment" maxstacksize="16" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="medcab" minamount="10" maxamount="16" spawnprobability="1"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.5"/>
-    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25"/>
+  <Item name="" identifier="suture" category="Equipment" maxstacksize="16" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="medcab" minamount="10" maxamount="16" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.5" />
+    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25" />
     <Fabricate suitablefabricators="medicalfabricator" amount="4" requiredtime="10">
-      <RequiredSkill identifier="medical" level="25"/>
-      <RequiredItem identifier="aluminium" mincondition="0.25" usecondition="true"/>
-      <RequiredItem identifier="organicfiber"/>
+      <RequiredSkill identifier="medical" level="25" />
+      <RequiredItem identifier="aluminium" mincondition="0.25" usecondition="true" />
+      <RequiredItem identifier="organicfiber" />
     </Fabricate>
-    <Deconstruct/>
+    <Deconstruct />
     <Price baseprice="30">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="25"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="25" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,0,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="256,128,128,128"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="65" height="45" density="50"/>
-    <SuitableTreatment identifier="lacerations" suitability="70"/>
-    <SuitableTreatment identifier="bitewounds" suitability="70"/>
-    <SuitableTreatment identifier="explosiondamage" suitability="70"/>
-    <SuitableTreatment identifier="gunshotwound" suitability="70"/>
-    <SuitableTreatment identifier="bleeding" suitability="30"/>
-    <SuitableTreatment identifier="retractedskin" suitability="50"/>
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
-      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="256,128,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="65" height="45" density="50" />
+    <SuitableTreatment identifier="lacerations" suitability="70" />
+    <SuitableTreatment identifier="bitewounds" suitability="70" />
+    <SuitableTreatment identifier="explosiondamage" suitability="70" />
+    <SuitableTreatment identifier="gunshotwound" suitability="70" />
+    <SuitableTreatment identifier="bleeding" suitability="30" />
+    <SuitableTreatment identifier="retractedskin" suitability="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" tags="medical" target="This, Limb">
-        <Sound file="%ModDir%/Sound/suture.ogg" range="500"/>
+        <Sound file="%ModDir%/Sound/suture.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
-  
-  
   <!-- /// First aid /// -->
-
   <!-- Tourniquet / clamps bleeding arteries / causes gangrene if left on for too long -->
-  <Item name="" identifier="tourniquet" category="Equipment" maxstacksize="4" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.250">
-    <PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>
-    <PreferredContainer primary="medcab" minamount="1" maxamount="2" spawnprobability="1"/>
+  <Item name="" identifier="tourniquet" category="Equipment" maxstacksize="4" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.250">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0.2" />
+    <PreferredContainer primary="medcab" minamount="1" maxamount="2" spawnprobability="1" />
     <Fabricate suitablefabricators="medicalfabricator" amount="2">
-      <RequiredSkill identifier="medical" level="15"/>
-      <RequiredItem identifier="organicfiber"/>
+      <RequiredSkill identifier="medical" level="15" />
+      <RequiredItem identifier="organicfiber" />
     </Fabricate>
     <Deconstruct time="2">
-      <Item identifier="organicfiber" outcondition="0.25"/>
+      <Item identifier="organicfiber" outcondition="0.25" />
     </Deconstruct>
     <Price baseprice="60" soldbydefault="true">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,0,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="384,128,128,128"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="100" height="100" density="50"/>
-    <SuitableTreatment identifier="arterialcut" suitability="50"/>
-    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
-      <RequiredSkill identifier="medical" level="30"/>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="384,128,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="100" height="100" density="50" />
+    <SuitableTreatment identifier="arterialcut" suitability="50" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
+      <RequiredSkill identifier="medical" level="30" />
       <StatusEffect type="OnUse" target="This">
-        <Sound file="Content/Items/Medical/Bandage1.ogg" type="OnUse" range="500"/>
-        <Sound file="Content/Items/Medical/Bandage2.ogg" type="OnUse" range="500"/>
+        <Sound file="Content/Items/Medical/Bandage1.ogg" type="OnUse" range="500" />
+        <Sound file="Content/Items/Medical/Bandage2.ogg" type="OnUse" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-  
   <!-- Needle / prevents pneuomothorax from worsening -->
-  <Item name="" identifier="needle" category="Material" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,medical,syringe,surgerytool"
-          description=""
-          useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
-    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25"/>
+  <Item name="" identifier="needle" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,syringe,surgerytool" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5" />
+    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25" />
     <Price baseprice="80" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="40">
-      <RequiredSkill identifier="medical" level="20"/>
-      <RequiredItem identifier="plastic"/>
-      <RequiredItem identifier="aluminium" mincondition="0.25" usecondition="true"/>
+      <RequiredSkill identifier="medical" level="20" />
+      <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="aluminium" mincondition="0.25" usecondition="true" />
     </Fabricate>
     <Deconstruct>
-      <RequiredItem identifier="plastic"/>
+      <RequiredItem identifier="plastic" />
     </Deconstruct>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="640,256,128,128"
-            depth="0.55" origin="0.5,0.5"/>
-    <Body width="35" height="65" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,5"
-                 handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="640,256,128,128" depth="0.55" origin="0.5,0.5" />
+    <Body width="35" height="65" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnUse" target="This" disabledeltatime="true">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
-
-  
   <!-- /// Chemicals /// -->
-
   <!-- Ringer's solution / a better version of saline -->
-  <Item name="" identifier="ringerssolution" category="Material" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3"
-          useinhealthinterface="true" description="" scale="0.35" impactsoundtag="impact_soft">
-    <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-    <PreferredContainer primary="medcab" minamount="6" maxamount="8"/>
-    <PreferredContainer primary="supplycab" minamount="3" maxamount="4" spawnprobability="0.5"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="4"
-                        spawnprobability="0.5"/>
+  <Item name="" identifier="ringerssolution" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3" useinhealthinterface="true" description="" scale="0.35" impactsoundtag="impact_soft">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <PreferredContainer primary="medcab" minamount="6" maxamount="8" />
+    <PreferredContainer primary="supplycab" minamount="3" maxamount="4" spawnprobability="0.5" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="4" spawnprobability="0.5" />
     <Price baseprice="50">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="15"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="15" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="15">
-      <RequiredSkill identifier="medical" level="25"/>
-      <RequiredItem identifier="antibloodloss1"/>
-      <RequiredItem identifier="potassium"/>
-      <RequiredItem identifier="carbon"/>
+      <RequiredSkill identifier="medical" level="25" />
+      <RequiredItem identifier="antibloodloss1" />
+      <RequiredItem identifier="potassium" />
+      <RequiredItem identifier="carbon" />
     </Fabricate>
     <Deconstruct time="20">
-      <Item identifier="antibloodloss1" copycondition="true" mincondition="0.1"/>
-      <Item identifier="potassium" copycondition="true" mincondition="0.1"/>
+      <Item identifier="antibloodloss1" copycondition="true" mincondition="0.1" />
+      <Item identifier="potassium" copycondition="true" mincondition="0.1" />
     </Deconstruct>
-    <SuitableTreatment identifier="bloodloss" suitability="30"/>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,192,64,64" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="679,386,51,128" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="80" height="45" density="11"/>
-    <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-              msg="ItemMsgPickUpSelect">
-      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-      <RequiredSkill identifier="medical" level="20"/>
+    <SuitableTreatment identifier="bloodloss" suitability="30" />
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="679,386,51,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="80" height="45" density="11" />
+    <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <RequiredSkill identifier="medical" level="20" />
       <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        <Affliction identifier="afringerssolution" amount="5"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+        <Affliction identifier="afringerssolution" amount="5" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        <Affliction identifier="afringerssolution" amount="3"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+        <Affliction identifier="afringerssolution" amount="3" />
       </StatusEffect>
       <!-- Remove the item when fully used -->
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Holdable>
-    <AiTarget sightrange="1000" static="true"/>
+    <AiTarget sightrange="1000" static="true" />
   </Item>
-
   <!-- Mannitol / heals cerebral hypoxia / only if blood pressure and oxygen presence has been restored -->
-  <Item name="" identifier="mannitol" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25"/>
-    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+  <Item name="" identifier="mannitol" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" spawnprobability="0.2" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25" />
+    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01" />
     <Price baseprice="300" soldbydefault="false">
-        <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="60">
-        <RequiredSkill identifier="medical" level="80"/>
-        <RequiredItem identifier="adrenaline"/>
-        <RequiredItem identifier="ethanol"/>
-        <RequiredItem identifier="liquidoxygenite"/>
-        <RequiredItem identifier="stabilozine"/>
+      <RequiredSkill identifier="medical" level="80" />
+      <RequiredItem identifier="adrenaline" />
+      <RequiredItem identifier="ethanol" />
+      <RequiredItem identifier="liquidoxygenite" />
+      <RequiredItem identifier="stabilozine" />
     </Fabricate>
     <Deconstruct time="20">
-        <Item identifier="adrenaline" copycondition="true" mincondition="0.1"/>
-        <Item identifier="liquidoxygenite" copycondition="true" mincondition="0.1"/>
+      <Item identifier="adrenaline" copycondition="true" mincondition="0.1" />
+      <Item identifier="liquidoxygenite" copycondition="true" mincondition="0.1" />
     </Deconstruct>
-    <SuitableTreatment identifier="cerebralhypoxia" suitability="15"/>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,128,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="640,128,128,128" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="60"></RequiredSkill>
-        <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="afmannitol" amount="5"/>
-          <Affliction identifier="organdamage" amount="0.5"/>
-          <Affliction identifier="heartdamage" amount="1"/>
-          <Affliction identifier="kidneydamage" amount="1"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-            <Affliction identifier="afmannitol" amount="3"/>
-          <Affliction identifier="organdamage" amount="1"/>
-          <Affliction identifier="heartdamage" amount="2"/>
-          <Affliction identifier="kidneydamage" amount="2"/>
-        </StatusEffect>
-        <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-        </StatusEffect>
+    <SuitableTreatment identifier="cerebralhypoxia" suitability="15" />
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="640,128,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+      <RequiredSkill identifier="medical" level="60"></RequiredSkill>
+	  <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	  <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
+      <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
+        <Affliction identifier="afmannitol" amount="5" />
+        <Affliction identifier="organdamage" amount="0.5" />
+        <Affliction identifier="heartdamage" amount="1" />
+        <Affliction identifier="kidneydamage" amount="1" />
+      </StatusEffect>
+      <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
+        <Affliction identifier="afmannitol" amount="3" />
+        <Affliction identifier="organdamage" amount="1" />
+        <Affliction identifier="heartdamage" amount="2" />
+        <Affliction identifier="kidneydamage" amount="2" />
+      </StatusEffect>
+      <StatusEffect type="OnSuccess" target="UseTarget">
+        <Conditional entitytype="eq Character"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+      </StatusEffect>
+      <StatusEffect type="OnFailure" target="UseTarget">
+        <Conditional entitytype="eq Character"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+        <Affliction identifier="stun" amount="0.1" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
-    <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="10">
-            <Affliction identifier="afmannitol" amount="3"/>
-        </StatusEffect>
-    </Projectile>
+    <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
   </Item>
   <!-- Azathioprine / immunosuppressant -->
-  <Item name="" identifier="immunosuppressant" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.3"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
-    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+  <Item name="" identifier="immunosuppressant" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.3" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" spawnprobability="0.2" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1" />
+    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01" />
     <Price baseprice="100" soldbydefault="false">
-        <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="3">
-        <RequiredSkill identifier="medical" level="50"/>
-        <RequiredItem identifier="ethanol"/>
-        <RequiredItem identifier="phosphorus"/>
-        <RequiredItem identifier="sulphuricacid"/>
+      <RequiredSkill identifier="medical" level="50" />
+      <RequiredItem identifier="ethanol" />
+      <RequiredItem identifier="phosphorus" />
+      <RequiredItem identifier="sulphuricacid" />
     </Fabricate>
-    <Deconstruct time="5">
-    </Deconstruct>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="196,196,64,64"
-                    origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="196,196,64,64" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
+    <Deconstruct time="5"></Deconstruct>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="196,196,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="196,196,64,64" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
     <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="10"/>
-        <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-          <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
-          <Affliction identifier="afimmunosuppressant" amount="5"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-          <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
-          <Affliction identifier="afimmunosuppressant" amount="3"/>
-          <Affliction identifier="sepsis" amount="0.1" probability="0.5"/>
-        </StatusEffect>
-        <StatusEffect type="OnBroken" target="This">
-          <Remove/>
-        </StatusEffect>
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <RequiredSkill identifier="medical" level="10" />
+      <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
+        <Sound file="%ModDir%/Sound/pills1.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" range="500" />
+        <Affliction identifier="afimmunosuppressant" amount="5" />
+      </StatusEffect>
+      <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
+        <Sound file="%ModDir%/Sound/pills1.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" range="500" />
+        <Affliction identifier="afimmunosuppressant" amount="3" />
+        <Affliction identifier="sepsis" amount="0.1" probability="0.5" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
   <!-- Thiamine / organ fixer -->
-  <Item name="" identifier="thiamine" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
-    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+  <Item name="" identifier="thiamine" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" spawnprobability="0.2" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1" />
+    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01" />
     <Price baseprice="100" soldbydefault="false">
-        <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="3">
-        <RequiredSkill identifier="medical" level="40"/>
-        <RequiredItem identifier="carbon" amount="2"/>
-        <RequiredItem identifier="sulphuricacid"/>
+      <RequiredSkill identifier="medical" level="40" />
+      <RequiredItem identifier="carbon" amount="2" />
+      <RequiredItem identifier="sulphuricacid" />
     </Fabricate>
-    <Deconstruct time="5">
-    </Deconstruct>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,192,64,64" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,384,128,128" depth="0.6" origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
+    <Deconstruct time="5"></Deconstruct>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="320,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,384,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
     <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="10"/>
-        <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-          <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
-          <Affliction identifier="afthiamine" amount="5"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-          <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
-          <Affliction identifier="afthiamine" amount="3"/>
-        </StatusEffect>
-        <StatusEffect type="OnBroken" target="This">
-          <Remove/>
-        </StatusEffect>
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <RequiredSkill identifier="medical" level="10" />
+      <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
+        <Sound file="%ModDir%/Sound/pills1.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" range="500" />
+        <Affliction identifier="afthiamine" amount="5" />
+      </StatusEffect>
+      <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
+        <Sound file="%ModDir%/Sound/pills1.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" range="500" />
+        <Affliction identifier="afthiamine" amount="3" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
   <!-- ??? / blood pressure reducer -->
-  <Item name="" identifier="pressuremeds" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
-    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+  <Item name="" identifier="pressuremeds" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" spawnprobability="0.2" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1" />
+    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01" />
     <Price baseprice="100" soldbydefault="false">
-        <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="3">
-        <RequiredSkill identifier="medical" level="30"/>
-        <RequiredItem identifier="sodium"/>
-        <RequiredItem identifier="nitroglycerin"/>
+      <RequiredSkill identifier="medical" level="30" />
+      <RequiredItem identifier="sodium" />
+      <RequiredItem identifier="nitroglycerin" />
     </Fabricate>
-    <Deconstruct time="5">
-    </Deconstruct>
-    <InventoryIcon texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" depth="0.6" origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
+    <Deconstruct time="5"></Deconstruct>
+    <InventoryIcon texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
     <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="10"/>
-        <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-          <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
-          <Affliction identifier="afpressuredrug" amount="5"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-          <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
-          <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
-          <Affliction identifier="afpressuredrug" amount="3"/>
-        </StatusEffect>
-        <StatusEffect type="OnBroken" target="This">
-          <Remove/>
-        </StatusEffect>
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <RequiredSkill identifier="medical" level="10" />
+      <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
+        <Sound file="%ModDir%/Sound/pills1.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" range="500" />
+        <Affliction identifier="afpressuredrug" amount="5" />
+      </StatusEffect>
+      <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
+        <Sound file="%ModDir%/Sound/pills1.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" range="500" />
+        <Affliction identifier="afpressuredrug" amount="3" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
   </Item>
   <!-- Streptokinase / heals heart attack -->
-  <Item name="" identifier="streptokinase" category="Material" cargocontaineridentifier="mediccrate"
-      Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275"
-      impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25"/>
-    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+  <Item name="" identifier="streptokinase" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" spawnprobability="0.2" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25" />
+    <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01" />
     <Price baseprice="100" soldbydefault="false">
-        <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="30" amount="2">
-        <RequiredSkill identifier="medical" level="40"/>
-        <RequiredItem identifier="slimebacteria"/>
-        <RequiredItem identifier="stabilozine"/>
+      <RequiredSkill identifier="medical" level="40" />
+      <RequiredItem identifier="slimebacteria" />
+      <RequiredItem identifier="stabilozine" />
     </Fabricate>
     <Deconstruct time="20">
-        <Item identifier="stabilozine" copycondition="true" mincondition="0.1"/>
+      <Item identifier="stabilozine" copycondition="true" mincondition="0.1" />
     </Deconstruct>
-    <SuitableTreatment identifier="heartattack" suitability="15"/>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,192,64,64" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="896,384,128,128" depth="0.6" origin="0.5,0.5"/>
-    <Body width="35" height="70" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-        </StatusEffect>
+    <SuitableTreatment identifier="heartattack" suitability="15" />
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="256,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="896,384,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="70" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
     </MeleeWeapon>
-    <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <!-- doesnt do anything as a projectil -->
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-            <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-    </Projectile>
+    <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="false" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
   </Item>
-  
-  
   <!-- Ointment / heals infected wound -->
-  <Item name="" identifier="ointment" category="Equipment" Tags="smallitem,medical" maxstacksize="8"
-          useinhealthinterface="true" cargocontaineridentifier="mediccrate" scale="0.265" impactsoundtag="impact_soft">
-        <PreferredContainer primary="medcab" minamount="4" maxamount="6" spawnprobability="1"/>
-        <PreferredContainer primary="supplycab" minamount="1" maxamount="3" spawnprobability="0.2"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="6" spawnprobability="0.5"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="3" spawnprobability="0.25"/>
-        <Price baseprice="40">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="40"/>
-        </Price>
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="4">
-            <RequiredSkill identifier="medical" level="15"/>
-            <RequiredItem identifier="stabilozine"/>
-            <RequiredItem identifier="antibiotics"/>
-        </Fabricate>
-        <Deconstruct time="20">
-            <Item identifier="stabilozine" mincondition="0.1" outcondition="0.25"/>
-        </Deconstruct>
-        <SuitableTreatment identifier="infectedwound" suitability="20"/>
-        <SuitableTreatment identifier="burn" suitability="15"/>
-        <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,64,64,64"
-                       origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="128,256,128,128" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="60" height="20" density="20"/>
-        <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                     handle1="-5,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
-            <!-- Remove the item when fully used -->
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </MeleeWeapon>
-    </Item>
-
+  <Item name="" identifier="ointment" category="Equipment" Tags="smallitem,medical" maxstacksize="8" useinhealthinterface="true" cargocontaineridentifier="mediccrate" scale="0.265" impactsoundtag="impact_soft">
+    <PreferredContainer primary="medcab" minamount="4" maxamount="6" spawnprobability="1" />
+    <PreferredContainer primary="supplycab" minamount="1" maxamount="3" spawnprobability="0.2" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="6" spawnprobability="0.5" />
+    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="3" spawnprobability="0.25" />
+    <Price baseprice="40">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="40" />
+    </Price>
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="4">
+      <RequiredSkill identifier="medical" level="15" />
+      <RequiredItem identifier="stabilozine" />
+      <RequiredItem identifier="antibiotics" />
+    </Fabricate>
+    <Deconstruct time="20">
+      <Item identifier="stabilozine" mincondition="0.1" outcondition="0.25" />
+    </Deconstruct>
+    <SuitableTreatment identifier="infectedwound" suitability="20" />
+    <SuitableTreatment identifier="burn" suitability="15" />
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="128,256,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="60" height="20" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
+      <!-- Remove the item when fully used -->
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </MeleeWeapon>
+  </Item>
   <!-- Antiseptic / same as above -->
-  <Item name="" identifier="antisepticspray" category="Equipment" Tags="smallitem,tool,medical"
-          useinhealthinterface="true" cargocontaineridentifier="metalcrate" description="" Scale="0.5"
-          impactsoundtag="impact_soft">
-        <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.5"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25"/>
-        <Price baseprice="75">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,64,64,64"
-                       origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="384,256,128,128"
-                depth="0.55" origin="0.5,0.5"/>
-        <Deconstruct time="5">
-            <Item identifier="plastic" outcondition="0.5"/>
-        </Deconstruct>
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="10">
-            <RequiredItem identifier="plastic"/>
-        </Fabricate>
-        <Body width="150" height="60" density="40"/>
-        <SuitableTreatment identifier="infectedwound" suitability="45"/>
-        <Pickable slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect"/>
-        <Holdable slots="Any,RightHand,LeftHand" controlpose="true" aimpos="30,0" handle1="0,-7" handle2="95, 10"
-                  msg="ItemMsgPickUpSelect"/>
-        <RepairTool range="200" barrelpos="15,5" combatpriority="10">
-            <ParticleEmitter particle="extinguisher" particlespersecond="15" copyentityangle="true" velocitymin="200.0"
-                             velocitymax="250.0"/>
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItems items="antiseptic" type="Contained" msg="Antiseptic Required"/>
-            <StatusEffect type="OnUse" target="This" Condition="-100" disabledeltatime="true"/>
-            <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="2"
-                          stackable="false"/>
-            <StatusEffect type="OnUse" targettype="Contained" targets="antiseptic" disabledeltatime="true"
-                          Condition="-10.0"/>
-            <StatusEffect tags="medical" type="OnUse" target="Limb" disabledeltatime="true">
-                <Sound file="%ModDir%/Sound/spray.ogg" range="500"/>
-                <ReduceAffliction identifier="infectedwound" amount="100"/>
-                <Affliction identifier="ointmented" amount="5"/>
-            </StatusEffect>
-        </RepairTool>
-        <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="-35,3" containedspritedepth="0.56"
-                       ItemRotation="-90" containedstateindicatorstyle="tank">
-            <Containable items="antiseptic"/>
-        </ItemContainer>
-    </Item>
-  <Item name="" identifier="antiseptic" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          description="" Tags="smallitem,chem,medical" scale="0.3">
-        <Upgrade gameversion="0.10.0.0" scale="0.3"/>
-        <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="6" spawnprobability="0.25"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="3" spawnprobability="0.15"/>
-        <Price baseprice="60">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3"/>
-        </Price>
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="15">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="chlorine"/>
-            <RequiredItem identifier="ethanol"/>
-        </Fabricate>
-        <Deconstruct time="5">
-            <Item identifier="chlorine"/>
-        </Deconstruct>
-        <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="192,64,64,64"
-                       origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="256,256,128,128" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="30" height="55" density="20"/>
-        <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="5,3" holdangle="10" reload="1.0" CanBeCombined="true" RemoveOnCombined="true">
-            <!-- Remove the item when fully used -->
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </MeleeWeapon>
-    </Item>
-
+  <Item name="" identifier="antisepticspray" category="Equipment" Tags="smallitem,tool,medical" useinhealthinterface="true" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_soft">
+    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.5" />
+    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25" />
+    <Price baseprice="75">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
+    </Price>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="128,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="384,256,128,128" depth="0.55" origin="0.5,0.5" />
+    <Deconstruct time="5">
+      <Item identifier="plastic" outcondition="0.5" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="10">
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <Body width="150" height="60" density="40" />
+    <SuitableTreatment identifier="infectedwound" suitability="45" />
+    <Pickable slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" />
+    <Holdable slots="Any,RightHand,LeftHand" controlpose="true" aimpos="30,0" handle1="0,-7" handle2="95, 10" msg="ItemMsgPickUpSelect" />
+    <RepairTool range="200" barrelpos="15,5" combatpriority="10">
+      <ParticleEmitter particle="extinguisher" particlespersecond="15" copyentityangle="true" velocitymin="200.0" velocitymax="250.0" />
+      <RequiredSkill identifier="medical" level="40" />
+      <RequiredItems items="antiseptic" type="Contained" msg="Antiseptic Required" />
+      <StatusEffect type="OnUse" target="This" Condition="-100" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="2" stackable="false" />
+      <StatusEffect type="OnUse" targettype="Contained" targets="antiseptic" disabledeltatime="true" Condition="-10.0" />
+      <StatusEffect tags="medical" type="OnUse" target="Limb" disabledeltatime="true">
+        <Sound file="%ModDir%/Sound/spray.ogg" range="500" />
+        <ReduceAffliction identifier="infectedwound" amount="100" />
+        <Affliction identifier="ointmented" amount="5" />
+      </StatusEffect>
+    </RepairTool>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="-35,3" containedspritedepth="0.56" ItemRotation="-90" containedstateindicatorstyle="tank">
+      <Containable items="antiseptic" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="antiseptic" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" description="" Tags="smallitem,chem,medical" scale="0.3">
+    <Upgrade gameversion="0.10.0.0" scale="0.3" />
+    <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="6" spawnprobability="0.25" />
+    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="3" spawnprobability="0.15" />
+    <Price baseprice="60">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3" />
+    </Price>
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="15">
+      <RequiredSkill identifier="medical" level="40" />
+      <RequiredItem identifier="chlorine" />
+      <RequiredItem identifier="ethanol" />
+    </Fabricate>
+    <Deconstruct time="5">
+      <Item identifier="chlorine" />
+    </Deconstruct>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="256,256,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="30" height="55" density="20" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="5,3" holdangle="10" reload="1.0" CanBeCombined="true" RemoveOnCombined="true">
+      <!-- Remove the item when fully used -->
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </MeleeWeapon>
+  </Item>
   <!-- Propofol / anesthetic -->
-  <Item name="" identifier="propofol" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5"
-          impactsoundtag="impact_metal_light">
-    <PreferredContainer primary="toxcab,abandonedtoxcab" secondary="toxcontainer" mincount="1" maxcount="1"
-                        spawnprobability="0.05"/>
+  <Item name="" identifier="propofol" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="toxcab,abandonedtoxcab" secondary="toxcontainer" mincount="1" maxcount="1" spawnprobability="0.05" />
     <Price baseprice="400" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <!--
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="90">
@@ -1377,71 +1190,54 @@
     </Fabricate>
     -->
     <Deconstruct time="20">
-      <Item identifier="paralyxis" copycondition="true" mincondition="0.1"/>
+      <Item identifier="paralyxis" copycondition="true" mincondition="0.1" />
     </Deconstruct>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,192,64,64" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="188,210,37,69" depth="0.6" origin="0.5,0.5"/>
-    <Body width="35" height="65" density="20"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="384,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="188,210,37,69" depth="0.6" origin="0.5,0.5" />
+    <Body width="35" height="65" density="20" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
       <!-- Remove the item when fully used -->
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
-    <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-      <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-      </StatusEffect>
-      <StatusEffect tags="poison" type="OnImpact" target="Character">
-        <Conditional mass="lt 100"/>
-        <Affliction identifier="anesthesia" amount="1"/>
-      </StatusEffect>
-    </Projectile>
+    <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="false" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
   </Item>
-
-  
-  
   <!-- /// Blood stuff /// -->
-  
   <Override>
-    <Item name="" identifier="antibloodloss2" nameidentifier="bloodpackominus" category="Medical" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true"
-          description="" scale="0.5" impactsoundtag="impact_soft">
+    <Item name="" identifier="antibloodloss2" nameidentifier="bloodpackominus" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medcab" minamount="2" maxamount="3" notcampaign="true"/>
-      <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="2" spawnprobability="0.2"/>
-      <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.05"/>
+      <PreferredContainer primary="medcab" minamount="2" maxamount="3" notcampaign="true" />
+      <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="2" spawnprobability="0.2" />
+      <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.05" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.2" />
-      <PreferredContainer secondary="medcontainer"/>
+      <PreferredContainer secondary="medcontainer" />
       <Price baseprice="240">
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
       <Deconstruct time="20">
-        <Item identifier="antibloodloss1" copycondition="true" mincondition="0.1"/>
-        <Item identifier="stabilozine" copycondition="true" mincondition="0.1"/>
+        <Item identifier="antibloodloss1" copycondition="true" mincondition="0.1" />
+        <Item identifier="stabilozine" copycondition="true" mincondition="0.1" />
       </Deconstruct>
-      <SuitableTreatment identifier="bloodloss" suitability="100"/>
-      <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="192,85,64,85" depth="0.6"
-					origin="0.5,0.5"/>
-      <Body width="80" height="42" density="11"/>
-      <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-					  msg="ItemMsgPickUpSelect">
+      <SuitableTreatment identifier="bloodloss" suitability="100" />
+      <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="192,85,64,85" depth="0.6" origin="0.5,0.5" />
+      <Body width="80" height="42" density="11" />
+      <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </Holdable>
-      <AiTarget sightrange="1000" static="true"/>
+      <AiTarget sightrange="1000" static="true" />
     </Item>
   </Override>
-
   <Item name="" identifier="bloodpackominus" nameidentifier="bloodpackominus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="300">
-      <Price storeidentifier="merchantmedical" sold="false" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="false" multiplier="0.9" minavailable="5" />
     </Price>
     <!--<Fabricate suitablefabricators="medicalfabricator" requiredtime="25">
       <RequiredSkill identifier="medical" level="30"/>
@@ -1451,241 +1247,201 @@
     </Fabricate>-->
   </Item>
   <Item name="" identifier="bloodpackoplus" nameidentifier="bloodpackoplus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="200">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
   <Item name="" identifier="bloodpackaminus" nameidentifier="bloodpackaminus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="200">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
   <Item name="" identifier="bloodpackaplus" nameidentifier="bloodpackaplus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="150">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
   <Item name="" identifier="bloodpackbminus" nameidentifier="bloodpackbminus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="200">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
   <Item name="" identifier="bloodpackbplus" nameidentifier="bloodpackbplus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="150">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
   <Item name="" identifier="bloodpackabminus" nameidentifier="bloodpackabminus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="150">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
   <Item name="" identifier="bloodpackabplus" nameidentifier="bloodpackabplus" variantof="antibloodloss2">
-    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
+    <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true" />
+    <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0" />
     <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
-    <PreferredContainer secondary="medcontainer"/>
+    <PreferredContainer secondary="medcontainer" />
     <Price baseprice="100">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5" />
     </Price>
   </Item>
-
-	
-  <Item name="" identifier="emptybloodpack" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical" useinhealthinterface="true" description="" scale="0.5"
-          impactsoundtag="impact_soft">
-		    <PreferredContainer primary="medcab" minamount="1" maxamount="2" spawnprobability="1"/>
-        <Price baseprice="25">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
-        </Price>
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="10">
-            <RequiredSkill identifier="medical" level="10"/>
-            <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true"/>
-        </Fabricate>
-        <Deconstruct time="10">
-          <Item identifier="plastic" mincondition="0.1" outcondition="0.25"/>
-        </Deconstruct>
-        <InventoryIcon texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="192,0,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="192,0,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </Holdable>
-    </Item>
-
-
-
-  <Item name="" identifier="ominuscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="opluscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="aminuscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="apluscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="bminuscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="bpluscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="abminuscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-  <Item name="" identifier="abpluscard" category="Equipment" description=""
-          Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-  <!-- Blood type analyzer + collection cartridge -->
-  <Item name="" description="" identifier="bloodanalyzer" category="Equipment" cargocontaineridentifier="metalcrate"
-          tags="smallitem,medical" useinhealthinterface="true" impactsoundtag="impact_metal_light" scale="0.4">
-
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.25"/>
-    <Price baseprice="250">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+  <Item name="" identifier="emptybloodpack" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="2" spawnprobability="1" />
+    <Price baseprice="25">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
     </Price>
-
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="10">
+      <RequiredSkill identifier="medical" level="10" />
+      <RequiredItem identifier="plastic" mincondition="0.5" usecondition="true" />
+    </Fabricate>
     <Deconstruct time="10">
-      <Item identifier="plastic"/>
-      <Item identifier="silicon"/>
+      <Item identifier="plastic" mincondition="0.1" outcondition="0.25" />
     </Deconstruct>
-    <Fabricate suitablefabricators="medicalfabricator" requiredtime="20">
-      <RequiredSkill identifier="medical" level="50"/>
-      <RequiredItem identifier="plastic"/>
-      <RequiredItem identifier="silicon"/>
-      <RequiredItem identifier="fpgacircuit"/>
-    </Fabricate>
-
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,128,64,64"
-                   origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="512,128,128,128" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="50" height="50" density="40"/>
-
-    <ItemComponent>
-      <StatusEffect type="OnUse" target="This, Character" comparison="And">
-        <Conditional condition="gt 90"/>
-        <Sound file="%ModDir%/Sound/hypospray.ogg"/>
-      </StatusEffect>
-
-      <StatusEffect type="OnUse" target="This" Condition="-100"/>
-      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5"
-                    stackable="false"/>
-    </ItemComponent>
-
-    <Pickable msg="ItemMsgPickUpSelect"/>
-
-    <ItemContainer capacity="1" maxstacksize="1" canbeselected="false" hideitems="true" drawinventory="true">
-      <Containable
-              items="bloodcollector, ominuscard, opluscard, aminuscard ,apluscard ,bminuscard ,bpluscard ,abminuscard , abpluscard"/>
-    </ItemContainer>
-  </Item>
-  <Item name="" identifier="bloodcollector" category="Material,Equipment" description=""
-          cargocontaineridentifier="mediccrate" Tags="smallitem,Material,vial,medical" useinhealthinterface="true" scale="0.170"
-          impactsoundtag="impact_metal_light" maxstacksize="8">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="8" spawnprobability="1"/>
-    <Price baseprice="5">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
-    </Price>
-    <Fabricate suitablefabricators="medicalfabricator" requiredtime="5">
-      <RequiredSkill identifier="medical" level="30"/>
-      <RequiredItem identifier="plastic" mincondition="0.25" usecondition="true"/>
-    </Fabricate>
-    <Deconstruct/>
-
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-    <Body width="16" height="12" density="20"/>
-    <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="50,0"
-              handle1="-5,0" reload="1.0" msg="ItemMsgPickUpSelect">
+    <InventoryIcon texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="192,0,64,85" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="192,0,64,85" depth="0.6" origin="0.5,0.5" />
+    <Body width="80" height="42" density="11" />
+    <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Holdable>
   </Item>
-
-  
-  
+  <Item name="" identifier="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="opluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="aminuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="apluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="bminuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="bpluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="abminuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <Item name="" identifier="abpluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <Deconstruct />
+  </Item>
+  <!-- Blood type analyzer + collection cartridge -->
+  <Item name="" description="" identifier="bloodanalyzer" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,medical" useinhealthinterface="true" impactsoundtag="impact_metal_light" scale="0.4">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.25" />
+    <Price baseprice="250">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="plastic" />
+      <Item identifier="silicon" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="20">
+      <RequiredSkill identifier="medical" level="50" />
+      <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="silicon" />
+      <RequiredItem identifier="fpgacircuit" />
+    </Fabricate>
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="0,128,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="512,128,128,128" depth="0.6" origin="0.5,0.5" />
+    <Body width="50" height="50" density="40" />
+    <ItemComponent>
+      <StatusEffect type="OnUse" target="This, Character" comparison="And">
+        <Conditional condition="gt 90" />
+        <Sound file="%ModDir%/Sound/hypospray.ogg" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This" Condition="-100" />
+      <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="5" stackable="false" />
+    </ItemComponent>
+    <Pickable msg="ItemMsgPickUpSelect" />
+    <ItemContainer capacity="1" maxstacksize="1" canbeselected="false" hideitems="true" drawinventory="true">
+      <Containable items="bloodcollector, ominuscard, opluscard, aminuscard ,apluscard ,bminuscard ,bpluscard ,abminuscard , abpluscard" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="bloodcollector" category="Material,Equipment" description="" cargocontaineridentifier="mediccrate" Tags="smallitem,Material,vial,medical" useinhealthinterface="true" scale="0.170" impactsoundtag="impact_metal_light" maxstacksize="8">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="8" spawnprobability="1" />
+    <Price baseprice="5">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
+    </Price>
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="5">
+      <RequiredSkill identifier="medical" level="30" />
+      <RequiredItem identifier="plastic" mincondition="0.25" usecondition="true" />
+    </Fabricate>
+    <Deconstruct />
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+    <Body width="16" height="12" density="20" />
+    <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="50,0" handle1="-5,0" reload="1.0" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Holdable>
+  </Item>
   <!-- /// new containers /// -->
-
-  <Item name="" identifier="organcrate" tags="crate,refrigerated" scale="0.5" linkable="true" pickdistance="150" showcontentsintooltip="true" impactsoundtag="impact_metal_heavy" waterproof="true" fireproof="true"
-        description="">
+  <Item name="" identifier="organcrate" tags="crate,refrigerated" scale="0.5" linkable="true" pickdistance="150" showcontentsintooltip="true" impactsoundtag="impact_metal_heavy" waterproof="true" fireproof="true" description="">
     <Price baseprice="150">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
     </Price>
     <Deconstruct time="10">
       <Item identifier="steel" />
@@ -1711,13 +1467,12 @@
       <Containable items="smallitem,organ" excludeditems="toolbox,cargoscooter" />
     </ItemContainer>
   </Item>
-  <Item name="" identifier="organtoolbox" category="Equipment" tags="smallitem,mobilecontainer,tool,refrigerated,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True"
-        description="">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer secondary="wreckstoragecab" spawnprobability="0.05"/>
-    <PreferredContainer secondary="locker"/>
+  <Item name="" identifier="organtoolbox" category="Equipment" tags="smallitem,mobilecontainer,tool,refrigerated,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True" description="">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer secondary="wreckstoragecab" spawnprobability="0.05" />
+    <PreferredContainer secondary="locker" />
     <Price baseprice="100">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
     </Price>
     <Deconstruct time="10">
       <Item identifier="steel" />
@@ -1731,7 +1486,7 @@
       <Item identifier="potassium" />
       <Item identifier="phosphorus" />
     </Fabricate>
-    <Price baseprice="25" >
+    <Price baseprice="25">
       <Price locationtype="outpost" multiplier="1" minavailable="4" />
       <Price locationtype="city" multiplier="0.9" minavailable="6" />
       <Price locationtype="research" multiplier="1.25" minavailable="1" />
@@ -1752,20 +1507,19 @@
     </ItemContainer>
     <aitarget sightrange="1000" soundrange="1000" fadeouttime="2" />
   </Item>
-  <Item name="" identifier="medtoolbox" category="Equipment" tags="smallitem,mobilecontainer,tool,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True"
-        description="">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer secondary="wreckstoragecab" spawnprobability="0.05"/>
-    <PreferredContainer secondary="locker"/>
+  <Item name="" identifier="medtoolbox" category="Equipment" tags="smallitem,mobilecontainer,tool,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True" description="">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer secondary="wreckstoragecab" spawnprobability="0.05" />
+    <PreferredContainer secondary="locker" />
     <Deconstruct time="10">
       <Item identifier="steel" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="20">
       <RequiredSkill identifier="mechanical" level="20" />
-      <Item identifier="steel" amount="2"/>
+      <Item identifier="steel" amount="2" />
     </Fabricate>
-    <Price baseprice="25" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3"/>
+    <Price baseprice="25">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3" />
     </Price>
     <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="1,403,84,67" origin="0.5,0.5" depth="0.6" />
     <Body width="90" height="60" density="20" />
@@ -1781,19 +1535,18 @@
     </ItemContainer>
     <aitarget sightrange="1000" soundrange="1000" fadeouttime="2" />
   </Item>
-  <Item name="" identifier="surgerytoolbox" category="Equipment" tags="smallitem,mobilecontainer,tool,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.375" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True"
-        description="">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-    <PreferredContainer secondary="locker"/>
+  <Item name="" identifier="surgerytoolbox" category="Equipment" tags="smallitem,mobilecontainer,tool,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.375" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True" description="">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <PreferredContainer secondary="locker" />
     <Deconstruct time="10">
       <Item identifier="steel" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="20">
       <RequiredSkill identifier="mechanical" level="20" />
-      <Item identifier="steel" amount="2"/>
+      <Item identifier="steel" amount="2" />
     </Fabricate>
-    <Price baseprice="25" >
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+    <Price baseprice="25">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
     <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="259,403,84,67" origin="0.5,0.5" depth="0.6" />
     <Body width="45" height="30" density="20" />
@@ -1809,19 +1562,18 @@
     </ItemContainer>
     <aitarget sightrange="1000" soundrange="1000" fadeouttime="2" />
   </Item>
-  <Item name="" identifier="medstartercrate" tags="crate" scale="0.5" linkable="true" pickdistance="150" showcontentsintooltip="true" impactsoundtag="impact_metal_heavy" waterproof="true" fireproof="true"
-        description="">
+  <Item name="" identifier="medstartercrate" tags="crate" scale="0.5" linkable="true" pickdistance="150" showcontentsintooltip="true" impactsoundtag="impact_metal_heavy" waterproof="true" fireproof="true" description="">
     <Price baseprice="150">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8" />
     </Price>
-    <Deconstruct/>
+    <Deconstruct />
     <Fabricate suitablefabricators="fabricator" requiredtime="10">
       <RequiredSkill identifier="mechanical" level="20" />
-      <Item identifier="steel" amount="8"/>
-      <Item identifier="copper" amount="2"/>
-      <Item identifier="zinc" amount="3"/>
-      <Item identifier="organicfiber" amount="6"/>
-      <Item identifier="plastic" amount="8"/>
+      <Item identifier="steel" amount="8" />
+      <Item identifier="copper" amount="2" />
+      <Item identifier="zinc" amount="3" />
+      <Item identifier="organicfiber" amount="6" />
+      <Item identifier="plastic" amount="8" />
     </Fabricate>
     <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" depth="0.54" sourcerect="158,578,146,82" origin="0.5,0.5" />
     <Body width="145" height="85" density="50" />
@@ -1838,14 +1590,14 @@
   <!-- a bodybag *is* a container of sorts, right? -->
   <Item name="" identifier="bodybag" category="Equipment" tags="provocative,mediumitem" scale="0.9" fireproof="false" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft">
     <Price baseprice="60" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="6"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="6" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="15">
       <RequiredSkill identifier="medical" level="5" />
       <RequiredItem identifier="plastic" />
     </Fabricate>
     <Deconstruct time="20">
-      <Item identifier="plastic" outcondition="0.5"/>
+      <Item identifier="plastic" outcondition="0.5" />
     </Deconstruct>
     <PreferredContainer primary="medcab" minamount="0" maxamount="4" spawnprobability="0.75" />
     <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.15" />
@@ -1871,15 +1623,15 @@
       <StatusEffect type="OnWearing" target="Character" OxygenAvailable="-100.0" UseHullOxygen="false" />
       <StatusEffect type="OnWearing" target="Character" HideFace="true" ObstructVision="true" SpeedMultiplier="0.8" LowPassMultiplier="0.2" setvalue="true" disabledeltatime="true" />
       <StatusEffect type="OnWearing" target="NearbyCharacters" range="100" stackable="true" setvalue="true">
-        <Conditional ishuman="true"/>
+        <Conditional ishuman="true" />
         <Affliction identifier="stretchers" amount="100" />
       </StatusEffect>
     </Wearable>
     <aitarget maxsightrange="50" />
   </Item>
-  <Item name="" identifier="stasisbag" category="Equipment" tags="provocative,mediumitem,diving" scale="0.9" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" equipconfirmationtext="stasisbagequipconfirmation">
+  <Item name="" identifier="stasisbag" category="Equipment" tags="provocative,mediumitem" scale="0.9" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" equipconfirmationtext="stasisbagequipconfirmation">
     <Price baseprice="1500" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="50">
       <RequiredSkill identifier="medical" level="50" />
@@ -1917,7 +1669,7 @@
       <StatusEffect tags="stasis" type="OnWearing" target="Character" duration="1" stackable="false" />
       <StatusEffect type="OnWearing" target="Character" disabledeltatime="true" stackable="false" duration="1">
         <!--<Affliction identifier="givein" amount="10" />-->
-        <Affliction identifier="stasis" amount="3"/>
+        <Affliction identifier="stasis" amount="3" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Character" HideFace="true" ObstructVision="true" PressureProtection="10000.0" SpeedMultiplier="0" LowPassMultiplier="0.2" setvalue="true" disabledeltatime="true">
         <Sound file="Content/Items/Diving/DivingSuitLoop1.ogg" range="500" />
@@ -1934,258 +1686,235 @@
     </Wearable>
     <aitarget maxsightrange="50" />
   </Item>
-
-  
-
   <!-- /// Limbs and organs /// -->
-
-  <Item name="" identifier="armlock1" description="" scale="0.5"
-          nonplayerteaminteractable="True" category="hidden">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
-        <Holdable slots="RightHand" handle1="0,0" msg="ItemMsgPickUpSelect">
-        <!--<Holdable selectkey="Action" pickkey="Use" slots="RightHand" msg="ItemMsgDetach" PickingTime="1" aimpos="85,-10"
+  <Item name="" identifier="armlock1" description="" scale="0.5" nonplayerteaminteractable="True" category="hidden">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
+    <Holdable slots="RightHand" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <!--<Holdable selectkey="Action" pickkey="Use" slots="RightHand" msg="ItemMsgDetach" PickingTime="1" aimpos="85,-10"
                   handle1="0,0" attachable="false" aimable="false">-->
-            <StatusEffect type="onnotcontained" target="This" disabledeltatime="true">
-                <Remove/>
-            </StatusEffect>
-        </Holdable>
-    </Item>
-  <Item name="" identifier="armlock2" description="" scale="0.5" nonplayerteaminteractable="True"
-          category="hidden">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
-        <Holdable slots="LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
-        <!--<Holdable selectkey="Action" pickkey="Use" slots="LeftHand" msg="ItemMsgDetach" PickingTime="1" aimpos="85,-10"
+      <StatusEffect type="onnotcontained" target="This" disabledeltatime="true">
+        <Remove />
+      </StatusEffect>
+    </Holdable>
+  </Item>
+  <Item name="" identifier="armlock2" description="" scale="0.5" nonplayerteaminteractable="True" category="hidden">
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
+    <Holdable slots="LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <!--<Holdable selectkey="Action" pickkey="Use" slots="LeftHand" msg="ItemMsgDetach" PickingTime="1" aimpos="85,-10"
                   handle1="0,0" attachable="false" aimable="false">-->
-            <StatusEffect type="onnotcontained" target="This" disabledeltatime="true">
-                <Remove/>
-            </StatusEffect>
-        </Holdable>
-    </Item>
-
+      <StatusEffect type="onnotcontained" target="This" disabledeltatime="true">
+        <Remove />
+      </StatusEffect>
+    </Holdable>
+  </Item>
   <Item name="" identifier="rarm" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,organ,petfood1,petfood2,petfood3">
-        <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" depth="0.6" origin="0.5,0.5"/>
-        <Body width="46" height="90" density="20"/>
-        <Deconstruct time="20">
-          <Item identifier="calcium"/>
-          <Item identifier="calcium"/>
-        </Deconstruct>
-        <Price baseprice="50" soldbydefault="false"></Price>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect target="Character" type="OnSpawn">
-                <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
-            </StatusEffect>
-          <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
-            <Conditional hastag="neq refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
-            <Conditional condition="gte 95" />
-            <Conditional hastag="refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnFire" target="This" Condition="-25.0" />
-          <!-- yuck! severed limbs on the floor! 
+    <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" depth="0.6" origin="0.5,0.5" />
+    <Body width="46" height="90" density="20" />
+    <Deconstruct time="20">
+      <Item identifier="calcium" />
+      <Item identifier="calcium" />
+    </Deconstruct>
+    <Price baseprice="50" soldbydefault="false"></Price>
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect target="Character" type="OnSpawn">
+        <Sound file="%ModDir%/Sound/severed.ogg" range="500" />
+      </StatusEffect>
+      <!-- making the limb go kaputt if left outside of refrigeration -->
+      <StatusEffect type="Always" target="This" condition="-0.2">
+        <Conditional hastag="neq refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
+        <Conditional condition="gte 95" />
+        <Conditional hastag="refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-25.0" />
+      <!-- yuck! severed limbs on the floor! 
           <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
             <Affliction identifier="nausea" amount="0.2"/>
           </StatusEffect>-->
-          <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-          </StatusEffect>
-        </Throwable>
-    </Item>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
   <Item name="" identifier="larm" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,organ,petfood1,petfood2,petfood3">
-        <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" depth="0.6" origin="0.5,0.5"/>
-        <Body width="46" height="90" density="20"/>
-        <Deconstruct time="20">
-          <Item identifier="calcium"/>
-          <Item identifier="calcium"/>
-        </Deconstruct>
-        <Price baseprice="50" soldbydefault="false"></Price>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect target="Character" type="OnSpawn">
-                <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
-            </StatusEffect>
-          <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
-            <Conditional hastag="neq refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
-            <Conditional condition="gte 95" />
-            <Conditional hastag="refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnFire" target="This" Condition="-25.0" />
-          <!-- yuck! severed limbs on the floor! 
+    <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="0,0,46,90" depth="0.6" origin="0.5,0.5" />
+    <Body width="46" height="90" density="20" />
+    <Deconstruct time="20">
+      <Item identifier="calcium" />
+      <Item identifier="calcium" />
+    </Deconstruct>
+    <Price baseprice="50" soldbydefault="false"></Price>
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect target="Character" type="OnSpawn">
+        <Sound file="%ModDir%/Sound/severed.ogg" range="500" />
+      </StatusEffect>
+      <!-- making the limb go kaputt if left outside of refrigeration -->
+      <StatusEffect type="Always" target="This" condition="-0.2">
+        <Conditional hastag="neq refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
+        <Conditional condition="gte 95" />
+        <Conditional hastag="refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-25.0" />
+      <!-- yuck! severed limbs on the floor! 
           <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
             <Affliction identifier="nausea" amount="0.2"/>
           </StatusEffect>-->
-          <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-          </StatusEffect>
-        </Throwable>
-    </Item>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
   <Item name="" identifier="rleg" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,organ,petfood1,petfood2,petfood3">
-        <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" origin="0.5,0.5"/>
-        <Body width="60" height="90" density="20"/>
-        <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" depth="0.6" origin="0.5,0.5"/>
-        <Deconstruct time="20">
-          <Item identifier="calcium"/>
-          <Item identifier="calcium"/>
-        </Deconstruct>
-        <Price baseprice="50" soldbydefault="false"></Price>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect target="Character" type="OnSpawn">
-                <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
-            </StatusEffect>
-          <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
-            <Conditional hastag="neq refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
-            <Conditional condition="gte 95" />
-            <Conditional hastag="refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnFire" target="This" Condition="-25.0" />
-          <!-- yuck! severed limbs on the floor! 
+    <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" origin="0.5,0.5" />
+    <Body width="60" height="90" density="20" />
+    <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" depth="0.6" origin="0.5,0.5" />
+    <Deconstruct time="20">
+      <Item identifier="calcium" />
+      <Item identifier="calcium" />
+    </Deconstruct>
+    <Price baseprice="50" soldbydefault="false"></Price>
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect target="Character" type="OnSpawn">
+        <Sound file="%ModDir%/Sound/severed.ogg" range="500" />
+      </StatusEffect>
+      <!-- making the limb go kaputt if left outside of refrigeration -->
+      <StatusEffect type="Always" target="This" condition="-0.2">
+        <Conditional hastag="neq refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
+        <Conditional condition="gte 95" />
+        <Conditional hastag="refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-25.0" />
+      <!-- yuck! severed limbs on the floor! 
           <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
             <Affliction identifier="nausea" amount="0.2"/>
           </StatusEffect>-->
-          <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-          </StatusEffect>
-        </Throwable>
-    </Item>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
   <Item name="" identifier="lleg" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,organ,petfood1,petfood2,petfood3">
-        <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" origin="0.5,0.5"/>
-        <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" depth="0.6" origin="0.5,0.5"/>
-        <Body width="60" height="90" density="20"/>
-        <Deconstruct time="20">
-          <Item identifier="calcium"/>
-          <Item identifier="calcium"/>
-        </Deconstruct>
-        <Price baseprice="50" soldbydefault="false"></Price>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect target="Character" type="OnSpawn">
-                <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
-            </StatusEffect>
-          <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
-            <Conditional hastag="neq refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
-            <Conditional condition="gte 95" />
-            <Conditional hastag="refrigerated" targetcontainer="true" />
-          </StatusEffect>
-          <StatusEffect type="OnFire" target="This" Condition="-25.0" />
-          <!-- yuck! severed limbs on the floor!
+    <InventoryIcon texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/limbs.png" sourcerect="57,0,60,90" depth="0.6" origin="0.5,0.5" />
+    <Body width="60" height="90" density="20" />
+    <Deconstruct time="20">
+      <Item identifier="calcium" />
+      <Item identifier="calcium" />
+    </Deconstruct>
+    <Price baseprice="50" soldbydefault="false"></Price>
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect target="Character" type="OnSpawn">
+        <Sound file="%ModDir%/Sound/severed.ogg" range="500" />
+      </StatusEffect>
+      <!-- making the limb go kaputt if left outside of refrigeration -->
+      <StatusEffect type="Always" target="This" condition="-0.2">
+        <Conditional hastag="neq refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
+        <Conditional condition="gte 95" />
+        <Conditional hastag="refrigerated" targetcontainer="true" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-25.0" />
+      <!-- yuck! severed limbs on the floor!
           <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
             <Affliction identifier="nausea" amount="0.2"/>
           </StatusEffect>-->
-          <StatusEffect type="OnBroken" target="This">
-            <Remove/>
-          </StatusEffect>
-        </Throwable>
-    </Item>
-
-  <Item name="" identifier="llegp" description="" scale="0.4" useinhealthinterface="True" 
-        Tags="smallitem,medical,surgery">
-        <Price baseprice="500" soldbydefault="false">
-            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
-        </Price>
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6"/>
-        <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5"/>
-        <Body width="60" height="90" density="20"/>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
-                <Conditional sll_amputation="gt 50"/>
-                <ReduceAffliction identifier="sll_amputation" amount="100"/>
-                <!--<Affliction identifier="llp" amount="100"/>-->
-            </StatusEffect>
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </Throwable>
-    </Item>
-  <Item name="" identifier="rlegp" description="" scale="0.4" useinhealthinterface="True"
-        Tags="smallitem,medical,surgery">
-        <Price baseprice="500" soldbydefault="false">
-          <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
-        </Price>
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6"/>
-        <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5"/>
-        <Body width="60" height="90" density="20"/>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
-                <Conditional srl_amputation="gt 50"/>
-                <ReduceAffliction identifier="srl_amputation" amount="100"/>
-                <!--<Affliction identifier="rlp" amount="100"/>-->
-            </StatusEffect>
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </Throwable>
-    </Item>
-  <Item name="" identifier="larmp" description="" scale="0.4" useinhealthinterface="True"
-        Tags="smallitem,medical,surgery">
-        <Price baseprice="500" soldbydefault="false">
-          <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
-        </Price>
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6"/>
-        <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5"/>
-        <Body width="60" height="90" density="20"/>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
-                <Conditional sla_amputation="gt 50"/>
-                <ReduceAffliction identifier="sla_amputation" amount="100"/>
-                <!--<Affliction identifier="lap" amount="100"/>-->
-            </StatusEffect>
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </Throwable>
-    </Item>
-  <Item name="" identifier="rarmp" description="" scale="0.4" useinhealthinterface="True"
-        Tags="smallitem,medical,surgery">
-        <Price baseprice="500" soldbydefault="false">
-          <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
-        </Price>
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6"/>
-        <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5"/>
-        <Body width="60" height="90" density="20"/>
-        <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand"
-                   throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-            <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
-                <Conditional sra_amputation="gt 50"/>
-                <ReduceAffliction identifier="sra_amputation" amount="100"/>
-                <!--<Affliction identifier="rap" amount="100"/>-->
-            </StatusEffect>
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </Throwable>
-    </Item>
-
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
+  <Item name="" identifier="llegp" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,medical,surgery">
+    <Price baseprice="500" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="90" density="20" />
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
+        <Conditional sll_amputation="gt 50" />
+        <ReduceAffliction identifier="sll_amputation" amount="100" />
+        <!--<Affliction identifier="llp" amount="100"/>-->
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
+  <Item name="" identifier="rlegp" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,medical,surgery">
+    <Price baseprice="500" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="90" density="20" />
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
+        <Conditional srl_amputation="gt 50" />
+        <ReduceAffliction identifier="srl_amputation" amount="100" />
+        <!--<Affliction identifier="rlp" amount="100"/>-->
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
+  <Item name="" identifier="larmp" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,medical,surgery">
+    <Price baseprice="500" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="90" density="20" />
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
+        <Conditional sla_amputation="gt 50" />
+        <ReduceAffliction identifier="sla_amputation" amount="100" />
+        <!--<Affliction identifier="lap" amount="100"/>-->
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
+  <Item name="" identifier="rarmp" description="" scale="0.4" useinhealthinterface="True" Tags="smallitem,medical,surgery">
+    <Price baseprice="500" soldbydefault="false">
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="90" density="20" />
+    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect Condition="-100.0" type="OnUse" target="UseTarget" disabledeltatime="true" comparison="And">
+        <Conditional sra_amputation="gt 50" />
+        <ReduceAffliction identifier="sra_amputation" amount="100" />
+        <!--<Affliction identifier="rap" amount="100"/>-->
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </Item>
   <!-- Organ transplants
   Thank you for not letting me spawn in items with specific conditions, Barotrauma -->
   <Item name="" identifier="livertransplant" description="" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
     <Price baseprice="1000" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1" />
     </Price>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="5,479,79,52" depth="0.6" origin="0.5,0.5"/>
-    <Body width="39" height="18" density="10"/>
-    <Deconstruct/>
-    
-    <Throwable characterusable="true" slots="Any,RightHand,LeftHand"
-               throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="5,479,79,52" depth="0.6" origin="0.5,0.5" />
+    <Body width="39" height="18" density="10" />
+    <Deconstruct />
+    <Throwable characterusable="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
         <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter1" decalsize="1.0" />
         <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" />
@@ -2203,22 +1932,21 @@
       <StatusEffect type="OnFire" target="This" Condition="-25.0" />
       <!-- yuck! organs on the floor! -->
       <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
-        <Affliction identifier="nausea" amount="0.2"/>
+        <Affliction identifier="nausea" amount="0.2" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Throwable>
-  
   </Item>
   <Item name="" identifier="livertransplant_q1" variantof="livertransplant" category="hidden">
     <Price baseprice="200" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
   </Item>
   <Item name="" identifier="livertransplant_q2" variantof="livertransplant" category="hidden">
     <Price baseprice="160" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="80" setvalue="true">
@@ -2228,7 +1956,7 @@
   </Item>
   <Item name="" identifier="livertransplant_q3" variantof="livertransplant" category="hidden">
     <Price baseprice="120" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="60" setvalue="true">
@@ -2238,7 +1966,7 @@
   </Item>
   <Item name="" identifier="livertransplant_q4" variantof="livertransplant" category="hidden">
     <Price baseprice="80" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="40" setvalue="true">
@@ -2248,7 +1976,7 @@
   </Item>
   <Item name="" identifier="livertransplant_q5" variantof="livertransplant" category="hidden">
     <Price baseprice="40" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="20" setvalue="true">
@@ -2256,17 +1984,14 @@
       </StatusEffect>
     </ItemComponent>
   </Item>
-  
   <Item name="" identifier="lungtransplant" description="" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
     <Price baseprice="2000" soldbydefault="false">
-      <Price locationtype="research" multiplier="1" sold="true" minavailable="2"/>
+      <Price locationtype="research" multiplier="1" sold="true" minavailable="2" />
     </Price>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="91,480,84,84" depth="0.6" origin="0.5,0.5"/>
-    <Body width="30" height="30" density="10"/>
-    <Deconstruct/>
-
-    <Throwable characterusable="true" slots="Any,RightHand,LeftHand"
-               throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="91,480,84,84" depth="0.6" origin="0.5,0.5" />
+    <Body width="30" height="30" density="10" />
+    <Deconstruct />
+    <Throwable characterusable="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
         <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter1" decalsize="1.0" />
         <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" />
@@ -2284,22 +2009,21 @@
       <StatusEffect type="OnFire" target="This" Condition="-25.0" />
       <!-- yuck! organs on the floor! -->
       <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
-        <Affliction identifier="nausea" amount="0.2"/>
+        <Affliction identifier="nausea" amount="0.2" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Throwable>
-
   </Item>
   <Item name="" identifier="lungtransplant_q1" variantof="lungtransplant" category="hidden">
     <Price baseprice="400" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
   </Item>
   <Item name="" identifier="lungtransplant_q2" variantof="lungtransplant" category="hidden">
     <Price baseprice="320" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="80" setvalue="true">
@@ -2309,7 +2033,7 @@
   </Item>
   <Item name="" identifier="lungtransplant_q3" variantof="lungtransplant" category="hidden">
     <Price baseprice="240" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="60" setvalue="true">
@@ -2319,7 +2043,7 @@
   </Item>
   <Item name="" identifier="lungtransplant_q4" variantof="lungtransplant" category="hidden">
     <Price baseprice="160" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="40" setvalue="true">
@@ -2329,7 +2053,7 @@
   </Item>
   <Item name="" identifier="lungtransplant_q5" variantof="lungtransplant" category="hidden">
     <Price baseprice="80" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="20" setvalue="true">
@@ -2337,17 +2061,14 @@
       </StatusEffect>
     </ItemComponent>
   </Item>
-
   <Item name="" identifier="kidneytransplant" description="" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
     <Price baseprice="400" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
     </Price>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="193,481,32,47" depth="0.6" origin="0.5,0.5"/>
-    <Body width="14" height="20" density="10"/>
-    <Deconstruct/>
-
-    <Throwable characterusable="true" slots="Any,RightHand,LeftHand"
-               throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="193,481,32,47" depth="0.6" origin="0.5,0.5" />
+    <Body width="14" height="20" density="10" />
+    <Deconstruct />
+    <Throwable characterusable="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
         <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter1" decalsize="1.0" />
         <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" />
@@ -2365,22 +2086,21 @@
       <StatusEffect type="OnFire" target="This" Condition="-25.0" />
       <!-- yuck! organs on the floor! -->
       <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
-        <Affliction identifier="nausea" amount="0.1"/>
+        <Affliction identifier="nausea" amount="0.1" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Throwable>
-
   </Item>
   <Item name="" identifier="kidneytransplant_q1" variantof="kidneytransplant" category="hidden">
     <Price baseprice="100" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
   </Item>
   <Item name="" identifier="kidneytransplant_q2" variantof="kidneytransplant" category="hidden">
     <Price baseprice="80" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="80" setvalue="true">
@@ -2390,7 +2110,7 @@
   </Item>
   <Item name="" identifier="kidneytransplant_q3" variantof="kidneytransplant" category="hidden">
     <Price baseprice="60" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="60" setvalue="true">
@@ -2400,7 +2120,7 @@
   </Item>
   <Item name="" identifier="kidneytransplant_q4" variantof="kidneytransplant" category="hidden">
     <Price baseprice="40" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="40" setvalue="true">
@@ -2410,7 +2130,7 @@
   </Item>
   <Item name="" identifier="kidneytransplant_q5" variantof="kidneytransplant" category="hidden">
     <Price baseprice="20" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="20" setvalue="true">
@@ -2418,17 +2138,14 @@
       </StatusEffect>
     </ItemComponent>
   </Item>
-
   <Item name="" identifier="hearttransplant" description="" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
     <Price baseprice="4000" soldbydefault="false">
-      <Price locationtype="research" multiplier="1" sold="true" minavailable="2"/>
+      <Price locationtype="research" multiplier="1" sold="true" minavailable="2" />
     </Price>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="238,479,28,54" depth="0.6" origin="0.5,0.5"/>
-    <Body width="14" height="22" density="10"/>
-    <Deconstruct/>
-
-    <Throwable characterusable="true" slots="Any,RightHand,LeftHand"
-               throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="238,479,28,54" depth="0.6" origin="0.5,0.5" />
+    <Body width="14" height="22" density="10" />
+    <Deconstruct />
+    <Throwable characterusable="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
         <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter1" decalsize="1.0" />
         <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" />
@@ -2446,22 +2163,21 @@
       <StatusEffect type="OnFire" target="This" Condition="-25.0" />
       <!-- yuck! organs on the floor! -->
       <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
-        <Affliction identifier="nausea" amount="0.2"/>
+        <Affliction identifier="nausea" amount="0.2" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Throwable>
-
   </Item>
   <Item name="" identifier="hearttransplant_q1" variantof="hearttransplant" category="hidden">
     <Price baseprice="600" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
   </Item>
   <Item name="" identifier="hearttransplant_q2" variantof="hearttransplant" category="hidden">
     <Price baseprice="500" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="80" setvalue="true">
@@ -2471,7 +2187,7 @@
   </Item>
   <Item name="" identifier="hearttransplant_q3" variantof="hearttransplant" category="hidden">
     <Price baseprice="400" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="60" setvalue="true">
@@ -2481,7 +2197,7 @@
   </Item>
   <Item name="" identifier="hearttransplant_q4" variantof="hearttransplant" category="hidden">
     <Price baseprice="300" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="40" setvalue="true">
@@ -2491,7 +2207,7 @@
   </Item>
   <Item name="" identifier="hearttransplant_q5" variantof="hearttransplant" category="hidden">
     <Price baseprice="200" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
     <ItemComponent>
       <StatusEffect type="Always" target="This" Condition="20" setvalue="true">
@@ -2499,17 +2215,14 @@
       </StatusEffect>
     </ItemComponent>
   </Item>
-
   <Item name="" identifier="braintransplant" description="" scale="0.3" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="1.5" Tags="smallitem,organ,petfood1,petfood2,petfood3,braintransplant">
     <Price baseprice="0" soldbydefault="false">
-      <Price storeidentifier="merchantmedical" sold="false"/>
+      <Price storeidentifier="merchantmedical" sold="false" />
     </Price>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="272,480,78,60" depth="0.6" origin="0.5,0.5"/>
-    <Body width="39" height="25" density="10"/>
-    <Deconstruct/>
-    
-    <Throwable characterusable="true" slots="Any,RightHand,LeftHand"
-               throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="272,480,78,60" depth="0.6" origin="0.5,0.5" />
+    <Body width="39" height="25" density="10" />
+    <Deconstruct />
+    <Throwable characterusable="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
       <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
         <Conditional hastag="neq braincontainer" targetcontainer="true" />
         <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter1" decalsize="1.0" />
@@ -2531,235 +2244,213 @@
       <StatusEffect type="OnFire" target="This" Condition="-50.0" />
       <!-- yuck! organs on the floor! -->
       <StatusEffect type="OnNotContained" target="NearbyCharacters" range="300">
-        <Affliction identifier="nausea" amount="0.2"/>
+        <Affliction identifier="nausea" amount="0.2" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </Throwable>
-  
   </Item>
-
   <!-- other -->
-  <Item name="" identifier="gypsum" category="Equipment" Tags="smallitem,medical"
-        maxstacksize="4" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description=""
-        scale="0.3" impactsoundtag="impact_soft">
-    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="0.5"/>
-    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1"
-                        spawnprobability="0.5"/>
-    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.125"/>
+  <Item name="" identifier="gypsum" category="Equipment" Tags="smallitem,medical" maxstacksize="4" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description="" scale="0.3" impactsoundtag="impact_soft">
+    <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="0.5" />
+    <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5" />
+    <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.125" />
     <Price baseprice="100">
-      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="6"/>
+      <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="6" />
     </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="1">
-      <RequiredSkill identifier="medical" level="15"/>
-      <RequiredItem identifier="calcium"/>
+      <RequiredSkill identifier="medical" level="15" />
+      <RequiredItem identifier="calcium" />
     </Fabricate>
     <Deconstruct time="5">
-      <Item identifier="calcium" mincondition="0.1" outcondition="0.5"/>
+      <Item identifier="calcium" mincondition="0.1" outcondition="0.5" />
     </Deconstruct>
-    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,192,64,64" origin="0.5,0.5"/>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="914,250,86,134" depth="0.6"
-            origin="0.5,0.5"/>
-    <Body width="41" height="64" density="40"/>
-    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                  handle1="-5,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
+    <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,192,64,64" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="914,250,86,134" depth="0.6" origin="0.5,0.5" />
+    <Body width="41" height="64" density="40" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
       <StatusEffect tags="medical" type="OnUse" target="This, Limb">
-        <Sound file="Content/Items/Medical/Bandage1.ogg" type="OnUse" range="500"/>
-        <Sound file="Content/Items/Medical/Bandage2.ogg" type="OnUse" range="500"/>
+        <Sound file="Content/Items/Medical/Bandage1.ogg" type="OnUse" range="500" />
+        <Sound file="Content/Items/Medical/Bandage2.ogg" type="OnUse" range="500" />
       </StatusEffect>
-
       <!-- Remove the item when fully used -->
       <StatusEffect type="OnBroken" target="This">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
-  <Item name="" identifier="blahaj" category="Equipment" cargocontaineridentifier="metalcrate" impactsoundtag="impact_squeak" RequireAimToUse="True"
-        Tags="smallitem,medical,mountableweapon" description="" useinhealthinterface="True" scale="0.25">
+  <Item name="" identifier="blahaj" category="Equipment" cargocontaineridentifier="metalcrate" impactsoundtag="impact_squeak" RequireAimToUse="True" Tags="smallitem,medical,mountableweapon" description="" useinhealthinterface="True" scale="0.25">
     <Fabricate suitablefabricators="fabricator" requiredtime="5">
-        <RequiredSkill identifier="mechanical" level="10"/>
-        <RequiredItem identifier="plastic"/>
+      <RequiredSkill identifier="mechanical" level="10" />
+      <RequiredItem identifier="plastic" />
     </Fabricate>
     <Deconstruct time="5">
-        <Item identifier="plastic" mincondition="0.1" outcondition="0.5"/>
+      <Item identifier="plastic" mincondition="0.1" outcondition="0.5" />
     </Deconstruct>
-    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,835,256,189" depth="0.55"
-            origin="0.5,0.5"/>
-    <Body width="100" height="80" density="9"/>
+    <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,835,256,189" depth="0.55" origin="0.5,0.5" />
+    <Body width="100" height="80" density="9" />
     <MeleeWeapon slots="Any,RightHand,LeftHand" controlpose="true" aimpos="45,10" handle1="-20,0" handle2="-10,5" holdangle="60" reload="1" range="100" combatpriority="5" msg="ItemMsgPickUpSelect">
-      <Attack stun="0.3" targetimpulse="2"/>
+      <Attack stun="0.3" targetimpulse="2" />
       <StatusEffect type="OnUse" target="This" disabledeltatime="true">
-        <Sound file="%ModDir%/Sound/squeak1.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak2.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak3.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak4.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak5.ogg" type="OnUse" range="500"/>
+        <Sound file="%ModDir%/Sound/squeak1.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak2.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak3.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak4.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak5.ogg" type="OnUse" range="500" />
       </StatusEffect>
       <StatusEffect type="Always" target="This" Condition="100" disabledeltatime="true" delay="2" stackable="false">
-        <Conditional condition="lt 50"/>
+        <Conditional condition="lt 50" />
       </StatusEffect>
     </MeleeWeapon>
   </Item>
-
   <!-- /// sound FX items (this is unelegant, pls fix, lua man!) /// -->
-
   <Item name="." identifier="ntsfx_selfscan" category="hidden" description=".">
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
         <Sound file="%ModDir%/Sound/selfscan.ogg" range="200" volume="0.5" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="1" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_scissors" category="hidden" description=".">
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
         <Sound file="%ModDir%/Sound/scissors1.ogg" selectionmode="random" range="200" volume="0.5" />
         <Sound file="%ModDir%/Sound/scissors2.ogg" range="200" volume="0.5" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="1" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_bandage" category="hidden" description=".">
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="Content/Items/Medical/Bandage2.ogg" type="OnUse" range="500"/>
-        <Sound file="Content/Items/Medical/Bandage1.ogg" type="OnUse" range="500"/>
+        <Sound file="Content/Items/Medical/Bandage2.ogg" type="OnUse" range="500" />
+        <Sound file="Content/Items/Medical/Bandage1.ogg" type="OnUse" range="500" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="1" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_pills" category="hidden" description=".">
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="%ModDir%/Sound/pills1.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/pills2.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/pills3.ogg" type="OnUse" range="500"/>
+        <Sound file="%ModDir%/Sound/pills1.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/pills2.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/pills3.ogg" type="OnUse" range="500" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="1" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_syringe" category="hidden" description=".">
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="Content/Items/Medical/Syringe.ogg" type="OnUse" range="500"/>
+        <Sound file="Content/Items/Medical/Syringe.ogg" type="OnUse" range="500" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.3" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_manualdefib" category="hidden" description=".">
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent>
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="%ModDir%/Sound/manualdefib.ogg" range="1000"/>
+        <Sound file="%ModDir%/Sound/manualdefib.ogg" range="1000" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.3" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_defib1" category="hidden" description=".">
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent>
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="%ModDir%/Sound/Defib1.ogg" range="1000"/>
+        <Sound file="%ModDir%/Sound/Defib1.ogg" range="1000" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.3" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_defib2" category="hidden" description=".">
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent>
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="%ModDir%/Sound/Defib2.ogg" range="1000"/>
+        <Sound file="%ModDir%/Sound/Defib2.ogg" range="1000" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.3" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_ointment" category="hidden" description=".">
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent>
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
-        <Sound file="%ModDir%/Sound/ointment.ogg" range="500"/>
+        <Sound file="%ModDir%/Sound/ointment.ogg" range="500" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.1" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
   <Item name="." identifier="ntsfx_squeak" category="hidden" description=".">
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5"/>
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="0.5" stackable="false">
-        <Sound file="%ModDir%/Sound/squeak1.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak2.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak3.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak4.ogg" type="OnUse" range="500"/>
-        <Sound file="%ModDir%/Sound/squeak5.ogg" type="OnUse" range="500"/>
+        <Sound file="%ModDir%/Sound/squeak1.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak2.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak3.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak4.ogg" type="OnUse" range="500" />
+        <Sound file="%ModDir%/Sound/squeak5.ogg" type="OnUse" range="500" />
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.5" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
-
-  
-
   <!-- /// VFX items (same as above, but visual!) ///-->
-
   <Item name="." identifier="ntvfx_explosion" category="hidden" description=".">
-    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,1,1" depth="0.6" origin="0.5,0.5" />
     <ItemComponent capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <StatusEffect type="always" target="This" disabledeltatime="true" duration="1" stackable="false">
         <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" type="OnUse" range="2000" />
-        <Explosion range="150.0" structuredamage="0" force="0" applyfireeffects="false">
-        </Explosion>
+        <Explosion range="150.0" structuredamage="0" force="0" applyfireeffects="false"></Explosion>
       </StatusEffect>
       <StatusEffect type="always" target="This" disabledeltatime="true" delay="0.3" stackable="false">
-        <Remove/>
+        <Remove />
       </StatusEffect>
     </ItemComponent>
   </Item>
-
-
-
   <!-- /// override section begins /// -->
   <Override>
-
-  <!-- Wrenches -->
+    <!-- Wrenches -->
     <Item name="" identifier="wrench" category="Equipment" Tags="smallitem,tool,simpletool,mechanicalrepairtool,wrenchitem,mountableweapon" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True" useinhealthinterface="True">
-      <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true"/>
-      <PreferredContainer primary="engcab"/>
-      <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" amount="1" spawnprobability="0.2"/>
-      <PreferredContainer primary="wreckengcab,abandonedengcab,outpostengcab,beaconengcab" amount="1" spawnprobability="0.5"/>
-      <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.3"/>
+      <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true" />
+      <PreferredContainer primary="engcab" />
+      <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" amount="1" spawnprobability="0.2" />
+      <PreferredContainer primary="wreckengcab,abandonedengcab,outpostengcab,beaconengcab" amount="1" spawnprobability="0.5" />
+      <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.3" />
       <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.1" />
       <Price baseprice="20" minavailable="10">
         <Price storeidentifier="merchantoutpost" />
@@ -2767,7 +2458,7 @@
         <Price storeidentifier="merchantresearch" multiplier="1.25" />
         <Price storeidentifier="merchantmilitary" multiplier="1.25" />
         <Price storeidentifier="merchantmine" />
-        <Price storeidentifier="merchantengineering" minavailable="10" multiplier="0.9"/>
+        <Price storeidentifier="merchantengineering" minavailable="10" multiplier="0.9" />
       </Price>
       <Deconstruct time="10">
         <Item identifier="iron" />
@@ -2779,10 +2470,10 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="450,0,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Tools/tools.png" sourcerect="161,235,64,20" depth="0.55" origin="0.5,0.5" />
       <Body width="60" height="15" density="50" />
-      <SuitableTreatment identifier="dislocation1" suitability="50"/>
-      <SuitableTreatment identifier="dislocation2" suitability="50"/>
-      <SuitableTreatment identifier="dislocation3" suitability="50"/>
-      <SuitableTreatment identifier="dislocation4" suitability="50"/>
+      <SuitableTreatment identifier="dislocation1" suitability="50" />
+      <SuitableTreatment identifier="dislocation2" suitability="50" />
+      <SuitableTreatment identifier="dislocation3" suitability="50" />
+      <SuitableTreatment identifier="dislocation4" suitability="50" />
       <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-8,0" holdangle="60" reload="1.0" range="50" combatpriority="8" msg="ItemMsgPickUpSelect">
         <Attack structuredamage="4" itemdamage="2" targetimpulse="5">
           <Affliction identifier="blunttrauma" strength="4" />
@@ -2792,16 +2483,13 @@
       </MeleeWeapon>
       <aitarget sightrange="500" soundrange="500" fadeouttime="1" />
       <Quality>
-        <QualityStat stattype="RepairSpeed" value="0.1"/>
+        <QualityStat stattype="RepairSpeed" value="0.1" />
       </Quality>
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
     </Item>
-
-  <!-- Scanner, ID card -->
-    <Item name="" identifier="healthscanner" scale="0.27" category="Equipment" tags="smallitem,tool,medical"
-          cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true"
-          requireaimtouse="True" useinhealthinterface="True">
-      <PreferredContainer primary="medcab" amount="1" spawnprobability="0.5" notcampaign="true"/>
+    <!-- Scanner, ID card -->
+    <Item name="" identifier="healthscanner" scale="0.27" category="Equipment" tags="smallitem,tool,medical" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true" requireaimtouse="True" useinhealthinterface="True">
+      <PreferredContainer primary="medcab" amount="1" spawnprobability="0.5" notcampaign="true" />
       <Price baseprice="150" minavailable="1">
         <Price storeidentifier="merchantoutpost" sold="false" multiplier="1.3" />
         <Price storeidentifier="merchantcity" multiplier="1.2" />
@@ -2811,27 +2499,22 @@
         <Price storeidentifier="merchantmedical" minavailable="8" />
       </Price>
       <Deconstruct time="10">
-        <Item identifier="aluminium"/>
+        <Item identifier="aluminium" />
       </Deconstruct>
       <Fabricate suitablefabricators="fabricator" requiredtime="10">
-        <RequiredSkill identifier="medical" level="40"/>
-        <RequiredItem identifier="fpgacircuit"/>
-        <RequiredItem identifier="aluminium"/>
+        <RequiredSkill identifier="medical" level="40" />
+        <RequiredItem identifier="fpgacircuit" />
+        <RequiredItem identifier="aluminium" />
       </Fabricate>
-
-      <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,64,64,64"
-                     origin="0.5,0.5"/>
-      <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,0,128,128"
-              depth="0.6" origin="0.5,0.5"/>
-      <Body width="112" height="96" density="25"/>
-
+      <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="448,64,64,64" origin="0.5,0.5" />
+      <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="768,0,128,128" depth="0.6" origin="0.5,0.5" />
+      <Body width="112" height="96" density="25" />
       <Holdable slots="Any,RightHand,LeftHand" holdpos="30,-15" aimpos="100,0" handle1="-13,0" handle2="-13,0" msg="ItemMsgPickUpSelect">
         <StatusEffect type="OnUse" target="This" Voltage="1.0" setvalue="true">
-          <RequiredItem items="mobilebattery" type="Contained"/>
+          <RequiredItem items="mobilebattery" type="Contained" />
         </StatusEffect>
       </Holdable>
-
-      <Propulsion force="0" >
+      <Propulsion force="0">
         <RequiredItems items="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired" />
         <StatusEffect type="OnUse" target="Contained" Condition="-1.0">
           <RequiredItem items="batterycell" type="Contained" />
@@ -2842,38 +2525,32 @@
         <StatusEffect type="OnUse" target="Contained" Condition="-1.0">
           <RequiredItem excludedidentifiers="batterycell,fulguriumbatterycell" type="Contained" />
         </StatusEffect>
-        
         <StatusEffect type="OnUse" target="NearbyCharacters" range="50">
-          <Affliction identifier="radiationsickness" amount="0.5"/>
+          <Affliction identifier="radiationsickness" amount="0.5" />
         </StatusEffect>
         <StatusEffect type="OnUse" target="Character">
-          <ReduceAffliction identifier="radiationsickness" amount="0.3"/>
+          <ReduceAffliction identifier="radiationsickness" amount="0.3" />
         </StatusEffect>
-
         <LightComponent LightColor="100,255,100,200" Flicker="0.5" range="10" powerconsumption="0">
           <LightTexture texture="Content/Lights/lightcone.png" origin="0.0, 0.4" size="4,4" />
         </LightComponent>
       </Propulsion>
-
-      <LightComponent LightColor="100,255,100,200" Flicker="0.25" range="10" powerconsumption="10"/>
+      <LightComponent LightColor="100,255,100,200" Flicker="0.25" range="10" powerconsumption="10" />
       <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
-        <Containable items="mobilebattery"/>
-        <StatusEffect type="Always" target="This" Voltage="-0.5"/>
+        <Containable items="mobilebattery" />
+        <StatusEffect type="Always" target="This" Voltage="-0.5" />
       </ItemContainer>
       <StatusHUD range="150" overlaycolor="0,50,25,30">
-        <StatusEffect type="Always" target="This,Character" drawhudwhenequipped="true" setvalue="true"
-                      comparison="And">
-          <Conditional Voltage="gt 0.5"/>
+        <StatusEffect type="Always" target="This,Character" drawhudwhenequipped="true" setvalue="true" comparison="And">
+          <Conditional Voltage="gt 0.5" />
         </StatusEffect>
-        <StatusEffect type="Always" target="This,Character" drawhudwhenequipped="false" setvalue="true"
-                      comparison="And">
-          <Conditional Voltage="lt 0.5"/>
+        <StatusEffect type="Always" target="This,Character" drawhudwhenequipped="false" setvalue="true" comparison="And">
+          <Conditional Voltage="lt 0.5" />
         </StatusEffect>
       </StatusHUD>
-
     </Item>
     <Item name="" identifier="idcard" category="Equipment" Tags="smallitem,identitycard" cargocontaineridentifier="metalcrate">
-      <PreferredContainer primary="crewcab"/>
+      <PreferredContainer primary="crewcab" />
       <Price baseprice="10">
         <Price storeidentifier="merchantoutpost" minavailable="4" />
         <Price storeidentifier="merchantcity" minavailable="6" />
@@ -2883,130 +2560,118 @@
       <Body width="16" height="12" density="20" />
       <IdCard slots="Card,Any" msg="ItemMsgPickUpSelect" />
       <ItemContainer capacity="1" maxstacksize="1" hideitems="true">
-        <Containable items="donorCard"/>
+        <Containable items="donorCard" />
       </ItemContainer>
     </Item>
-  <!-- Fluids -->
-    <Item name="" identifier="alienblood" category="Material" maxstacksize="8"
-          cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,chem,medical"
-          useinhealthinterface="true" scale="0.5">
-      <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-      <PreferredContainer primary="medfabcab" secondary="medcontainer"/>
-      <PreferredContainer secondary="storageorgan" minamount="1" maxamount="2" spawnprobability="1"/>
+    <!-- Fluids -->
+    <Item name="" identifier="alienblood" category="Material" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,chem,medical" useinhealthinterface="true" scale="0.5">
+      <Upgrade gameversion="0.10.0.0" scale="0.5" />
+      <PreferredContainer primary="medfabcab" secondary="medcontainer" />
+      <PreferredContainer secondary="storageorgan" minamount="1" maxamount="2" spawnprobability="1" />
       <Price baseprice="100" sold="false">
         <Price storeidentifier="merchantoutpost" multiplier="0.85" />
         <Price storeidentifier="merchantcity" multiplier="0.85" />
-        <Price storeidentifier="merchantresearch" sold="true" multiplier="1.2" minavailable="2"/>
+        <Price storeidentifier="merchantresearch" sold="true" multiplier="1.2" minavailable="2" />
         <Price storeidentifier="merchantmilitary" multiplier="0.9" />
         <Price storeidentifier="merchantmine" multiplier="0.85" />
       </Price>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="448,771,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/CreatureLoot/CreatureLoot.png" sourcerect="1,128,30,58" depth="0.6"
-              origin="0.5,0.5"/>
-      <Body width="30" height="55" density="20"/>
-      <MeleeWeapon canbecombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="40"/>
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="448,771,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/CreatureLoot/CreatureLoot.png" sourcerect="1,128,30,58" depth="0.6" origin="0.5,0.5" />
+      <Body width="30" height="55" density="20" />
+      <MeleeWeapon canbecombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0">
+        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+        <RequiredSkill identifier="medical" level="40" />
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="15.0">
-          <Affliction identifier="organdamage" amount="0.25"/>
-          <Affliction identifier="hemotransfusionshock" amount="6.6"/>
-          <ReduceAffliction identifier="bloodloss" amount="0.5"/>
+          <Affliction identifier="organdamage" amount="0.25" />
+          <Affliction identifier="hemotransfusionshock" amount="6.6" />
+          <ReduceAffliction identifier="bloodloss" amount="0.5" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="15.0">
-          <Affliction identifier="organdamage" amount="0.5"/>
-          <Affliction identifier="hemotransfusionshock" amount="6.6"/>
-          <ReduceAffliction identifier="bloodloss" amount="0.5"/>
+          <Affliction identifier="organdamage" amount="0.5" />
+          <Affliction identifier="hemotransfusionshock" amount="6.6" />
+          <ReduceAffliction identifier="bloodloss" amount="0.5" />
         </StatusEffect>
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
     </Item>
-    <Item name="" identifier="antibloodloss1" category="Medical" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3"
-          useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
-      <Upgrade gameversion="0.10.0.0" scale="0.5"/>
+    <Item name="" identifier="antibloodloss1" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
+      <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.1" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="3" spawnprobability="0.5" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="50" minavailable="12">
-        <Price storeidentifier="merchantoutpost"/>
-        <Price storeidentifier="merchantcity"/>
-        <Price storeidentifier="merchantresearch"/>
-        <Price storeidentifier="merchantmilitary"/>
-        <Price storeidentifier="merchantmine"/>
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantoutpost" />
+        <Price storeidentifier="merchantcity" />
+        <Price storeidentifier="merchantresearch" />
+        <Price storeidentifier="merchantmilitary" />
+        <Price storeidentifier="merchantmine" />
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="2" >
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="2">
         <RequiredSkill identifier="medical" level="5" />
-        <RequiredItem identifier="sodium"  />
+        <RequiredItem identifier="sodium" />
         <RequiredItem identifier="chlorine" amount="2" />
       </Fabricate>
-      <Deconstruct time="5"/>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="960,640,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,261,83,46" depth="0.6"
-              origin="0.5,0.5"/>
-      <Body width="80" height="45" density="11"/>
-      <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="10"/>
+      <Deconstruct time="5" />
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="960,640,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,261,83,46" depth="0.6" origin="0.5,0.5" />
+      <Body width="80" height="45" density="11" />
+      <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
+        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+        <RequiredSkill identifier="medical" level="10" />
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="afsaline" amount="5"/>
+          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+          <Affliction identifier="afsaline" amount="5" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="afsaline" amount="3"/>
+          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+          <Affliction identifier="afsaline" amount="3" />
         </StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </Holdable>
-      <AiTarget sightrange="1000" static="true"/>
+      <AiTarget sightrange="1000" static="true" />
     </Item>
-  <!-- Bandages -->
-    <Item name="" identifier="antibleeding1" aliases="Bandage" category="Medical" Tags="smallitem,medical"
-          maxstacksize="8" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description=""
-          scale="0.5" impactsoundtag="impact_soft">
+    <!-- Bandages -->
+    <Item name="" identifier="antibleeding1" aliases="Bandage" category="Medical" Tags="smallitem,medical" maxstacksize="8" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description="" scale="0.5" impactsoundtag="impact_soft">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer secondary="supplycab" minamount="1" maxamount="2" spawnprobability="0.5" notcampaign="true"/>
+      <PreferredContainer secondary="supplycab" minamount="1" maxamount="2" spawnprobability="0.5" notcampaign="true" />
       <PreferredContainer secondary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.3" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.8" />
       <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.5" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.2" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="30" minavailable="25">
-        <Price storeidentifier="merchantoutpost"/>
-        <Price storeidentifier="merchantcity"/>
-        <Price storeidentifier="merchantresearch"/>
-        <Price storeidentifier="merchantmilitary"/>
-        <Price storeidentifier="merchantmine"/>
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantoutpost" />
+        <Price storeidentifier="merchantcity" />
+        <Price storeidentifier="merchantresearch" />
+        <Price storeidentifier="merchantmilitary" />
+        <Price storeidentifier="merchantmine" />
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
       <Fabricate suitablefabricators="medicalfabricator" requiredtime="15" amount="3">
         <RequiredSkill identifier="medical" level="5" />
         <RequiredItem identifier="organicfiber" />
       </Fabricate>
-      <Deconstruct time="2"/>
+      <Deconstruct time="2" />
       <SuitableTreatment type="bleeding" suitability="30" />
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="310,33,26,42" depth="0.6" origin="0.5,0.5" />
       <Body width="25" height="40" density="20" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
     </Item>
-    <Item name="" identifier="antibleeding2" category="Medical" Tags="smallitem,medical" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5"
-          impactsoundtag="impact_soft">
+    <Item name="" identifier="antibleeding2" category="Medical" Tags="smallitem,medical" maxstacksize="8" cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_soft">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.4" />
       <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.3" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.1" />
@@ -3018,58 +2683,55 @@
         <RequiredItem identifier="antibleeding1" amount="3" />
         <RequiredItem identifier="elastin" />
       </Fabricate>
-      <Deconstruct time="2"/>
+      <Deconstruct time="2" />
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="959,771,63,59" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="340,33,26,42" depth="0.6" origin="0.5,0.5" />
       <Body width="25" height="40" density="20" />
-      <SuitableTreatment identifier="bleeding" suitability="32"/>
-      <SuitableTreatment identifier="burn" suitability="35"/>
-      <SuitableTreatment identifier="infectedwound" suitability="6"/>
-      <SuitableTreatment identifier="dirtybandage" suitability="100"/>
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
+      <SuitableTreatment identifier="bleeding" suitability="32" />
+      <SuitableTreatment identifier="burn" suitability="35" />
+      <SuitableTreatment identifier="infectedwound" suitability="6" />
+      <SuitableTreatment identifier="dirtybandage" suitability="100" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="10" reload="1.0" msg="ItemMsgPickUpSelect">
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
     </Item>
-  <!-- Beds -->
-    <Item name="" identifier="opdeco_hospitalbed" width="416" height="192" texturescale="1.0,1.0" scale="0.5"
-          noninteractable="false" category="Decorative">
-      <Upgrade gameversion="0.12.0.0" noninteractable="false"/>
-      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.97"
-              premultiplyalpha="false" origin="0.5,0.5"/>
+    <!-- Beds -->
+    <Item name="" identifier="opdeco_hospitalbed" width="416" height="192" texturescale="1.0,1.0" scale="0.5" noninteractable="false" category="Decorative">
+      <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
       <ItemComponent>
         <StatusEffect type="OnNotContained" target="NearbyCharacters" range="200" stackable="true">
-          <Affliction identifier="table" amount="2"/>
-          <Affliction identifier="alv" amount="10"/>
+          <Affliction identifier="table" amount="2" />
+          <Affliction identifier="alv" amount="10" />
         </StatusEffect>
         <StatusEffect type="Always" target="NearbyCharacters" range="200" delay="1" stackable="false">
           <LuaHook name="surgerytable.update" />
         </StatusEffect>
       </ItemComponent>
       <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true">
-        <limbposition limb="Head" position="-6,-10" allowusinglimb="true"/>
-        <limbposition limb="Torso" position="104,0" allowusinglimb="true"/>
-        <limbposition limb="Waist" position="244,-80" allowusinglimb="true"/>
-        <limbposition limb="RightFoot" position="380,-20" allowusinglimb="true"/>
-        <limbposition limb="LeftFoot" position="380,-20" allowusinglimb="true"/>
-        <limbposition limb="RightHand" position="234,-10" allowusinglimb="false"/>
-        <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false"/>
+        <limbposition limb="Head" position="-6,-10" allowusinglimb="true" />
+        <limbposition limb="Torso" position="104,0" allowusinglimb="true" />
+        <limbposition limb="Waist" position="244,-80" allowusinglimb="true" />
+        <limbposition limb="RightFoot" position="380,-20" allowusinglimb="true" />
+        <limbposition limb="LeftFoot" position="380,-20" allowusinglimb="true" />
+        <limbposition limb="RightHand" position="234,-10" allowusinglimb="false" />
+        <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false" />
         <StatusEffect type="OnActive" target="Character">
-          <reduceaffliction identifier="nausea" strength="0.05"/>
-          <reduceaffliction identifier="opiatewithdrawal" strength="0.05"/>
-          <reduceaffliction identifier="opiateaddiction" strength="0.05"/>
-          <reduceaffliction identifier="drunk" strength="0.05"/>
+          <reduceaffliction identifier="nausea" strength="0.05" />
+          <reduceaffliction identifier="opiatewithdrawal" strength="0.05" />
+          <reduceaffliction identifier="opiateaddiction" strength="0.05" />
+          <reduceaffliction identifier="drunk" strength="0.05" />
         </StatusEffect>
       </Controller>
       <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
         <GuiFrame relativesize="0.15,0.6" minsize="300,450" maxsize="380,500" anchor="Center" style="ConnectionPanel" />
         <RequiredItem items="screwdriver" type="Equipped" />
         <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
-        <output name="alive_out" displayname="connection.aliveout"/>
-        <output name="conscious_out" displayname="connection.consciousout"/>
+        <output name="alive_out" displayname="connection.aliveout" />
+        <output name="conscious_out" displayname="connection.consciousout" />
         <output name="name_out" displayname="connection.nameout" />
         <output name="vitality_out" displayname="connection.vitalityout" />
         <output name="heartrate_out" displayname="connection.heartrateout" />
@@ -3083,148 +2745,135 @@
         <output name="bloodph_out" displayname="connection.bloodphout" />
       </ConnectionPanel>
     </Item>
-    <Item name="" identifier="opdeco_bunkbeds" width="356" height="264" texturescale="1.0,1.0" scale="0.5"
-          category="Decorative" spritecolor="255,255,255,255">
-      <Upgrade gameversion="0.12.0.0" noninteractable="false"/>
-      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1600,1760,384,264" depth="0.85"
-              premultiplyalpha="false" origin="0.5,0.5"/>
+    <Item name="" identifier="opdeco_bunkbeds" width="356" height="264" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255">
+      <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1600,1760,384,264" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
       <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true">
-        <limbposition limb="Head" position="-26,-170"/>
-        <limbposition limb="Torso" position="84,-140"/>
-        <limbposition limb="Waist" position="224,-160"/>
-        <limbposition limb="RightFoot" position="444,-160"/>
-        <limbposition limb="LeftFoot" position="444,-160"/>
-        <limbposition limb="RightHand" position="224,-160" allowusinglimb="false"/>
-        <limbposition limb="LeftHand" position="224,-160" allowusinglimb="false"/>
+        <limbposition limb="Head" position="-26,-170" />
+        <limbposition limb="Torso" position="84,-140" />
+        <limbposition limb="Waist" position="224,-160" />
+        <limbposition limb="RightFoot" position="444,-160" />
+        <limbposition limb="LeftFoot" position="444,-160" />
+        <limbposition limb="RightHand" position="224,-160" allowusinglimb="false" />
+        <limbposition limb="LeftHand" position="224,-160" allowusinglimb="false" />
         <StatusEffect type="OnActive" target="Character">
-          <reduceaffliction identifier="nausea" strength="0.05"/>
-          <reduceaffliction identifier="opiatewithdrawal" strength="0.05"/>
-          <reduceaffliction identifier="opiateaddiction" strength="0.05"/>
-          <reduceaffliction identifier="drunk" strength="0.05"/>
-          <Affliction identifier="table" amount="2"/>
+          <reduceaffliction identifier="nausea" strength="0.05" />
+          <reduceaffliction identifier="opiatewithdrawal" strength="0.05" />
+          <reduceaffliction identifier="opiateaddiction" strength="0.05" />
+          <reduceaffliction identifier="drunk" strength="0.05" />
+          <Affliction identifier="table" amount="2" />
         </StatusEffect>
       </Controller>
     </Item>
-    <Item name="" identifier="opdeco_bunks1" nameidentifier="opdeco_bunks1" allowattachitems="false" width="463"
-          height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative">
-      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1296,1289,463,387" depth="0.85"
-              premultiplyalpha="false" origin="0.5,0.5"/>
-      <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86"
-                        origin="0.5,0.5" offset="40,-95"/>
-      <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86"
-                        origin="0.5,0.5" offset="40,105"/>
+    <Item name="" identifier="opdeco_bunks1" nameidentifier="opdeco_bunks1" allowattachitems="false" width="463" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1296,1289,463,387" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
+      <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,-95" />
+      <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,105" />
       <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true">
-        <limbposition limb="Head" position="14,-300"/>
-        <limbposition limb="Torso" position="124,-270"/>
-        <limbposition limb="Waist" position="264,-290"/>
-        <limbposition limb="RightFoot" position="484,-290"/>
-        <limbposition limb="LeftFoot" position="484,-290"/>
-        <limbposition limb="RightHand" position="264,-290" allowusinglimb="false"/>
-        <limbposition limb="LeftHand" position="264,-290" allowusinglimb="false"/>
+        <limbposition limb="Head" position="14,-300" />
+        <limbposition limb="Torso" position="124,-270" />
+        <limbposition limb="Waist" position="264,-290" />
+        <limbposition limb="RightFoot" position="484,-290" />
+        <limbposition limb="LeftFoot" position="484,-290" />
+        <limbposition limb="RightHand" position="264,-290" allowusinglimb="false" />
+        <limbposition limb="LeftHand" position="264,-290" allowusinglimb="false" />
         <StatusEffect type="OnActive" target="Character">
-          <reduceaffliction identifier="nausea" strength="0.05"/>
-          <reduceaffliction identifier="opiatewithdrawal" strength="0.05"/>
-          <reduceaffliction identifier="opiateaddiction" strength="0.05"/>
-          <reduceaffliction identifier="drunk" strength="0.05"/>
-          <Affliction identifier="table" amount="2"/>
+          <reduceaffliction identifier="nausea" strength="0.05" />
+          <reduceaffliction identifier="opiatewithdrawal" strength="0.05" />
+          <reduceaffliction identifier="opiateaddiction" strength="0.05" />
+          <reduceaffliction identifier="drunk" strength="0.05" />
+          <Affliction identifier="table" amount="2" />
         </StatusEffect>
       </Controller>
     </Item>
-    <Item name="" identifier="opdeco_prisonbed" allowattachitems="true" width="384" height="96"
-          texturescale="1.0,1.0" scale="0.5" category="Decorative">
-      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="864,1888,384,96" depth="0.98"
-              premultiplyalpha="false" origin="0.5,0.5"/>
+    <Item name="" identifier="opdeco_prisonbed" allowattachitems="true" width="384" height="96" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="864,1888,384,96" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
       <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true">
-        <limbposition limb="Head" position="-6,-10"/>
-        <limbposition limb="Torso" position="104,20"/>
-        <limbposition limb="Waist" position="244,-60"/>
-        <limbposition limb="RightFoot" position="380,0"/>
-        <limbposition limb="LeftFoot" position="380,0"/>
-        <limbposition limb="RightHand" position="234,10" allowusinglimb="false"/>
-        <limbposition limb="LeftHand" position="234,10" allowusinglimb="false"/>
+        <limbposition limb="Head" position="-6,-10" />
+        <limbposition limb="Torso" position="104,20" />
+        <limbposition limb="Waist" position="244,-60" />
+        <limbposition limb="RightFoot" position="380,0" />
+        <limbposition limb="LeftFoot" position="380,0" />
+        <limbposition limb="RightHand" position="234,10" allowusinglimb="false" />
+        <limbposition limb="LeftHand" position="234,10" allowusinglimb="false" />
         <StatusEffect type="OnActive" target="Character">
-          <reduceaffliction identifier="nausea" strength="0.05"/>
-          <reduceaffliction identifier="opiatewithdrawal" strength="0.05"/>
-          <reduceaffliction identifier="opiateaddiction" strength="0.05"/>
-          <reduceaffliction identifier="drunk" strength="0.05"/>
-          <Affliction identifier="table" amount="2"/>
+          <reduceaffliction identifier="nausea" strength="0.05" />
+          <reduceaffliction identifier="opiatewithdrawal" strength="0.05" />
+          <reduceaffliction identifier="opiateaddiction" strength="0.05" />
+          <reduceaffliction identifier="drunk" strength="0.05" />
+          <Affliction identifier="table" amount="2" />
         </StatusEffect>
       </Controller>
     </Item>
-  <!-- Opium, Morphine, Fentanyl, Naloxone -->
-    <Item name="" identifier="opium" category="Medical" maxstacksize="8" Tags="smallitem,chem,medical" description=""
-          cargocontaineridentifier="mediccrate" scale="0.5" useinhealthinterface="true">
-      <Upgrade gameversion="0.10.0.0" scale="0.5"/>
+    <!-- Opium, Morphine, Fentanyl, Naloxone -->
+    <Item name="" identifier="opium" category="Medical" maxstacksize="8" Tags="smallitem,chem,medical" description="" cargocontaineridentifier="mediccrate" scale="0.5" useinhealthinterface="true">
+      <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="abandonedmedcab,wreckmedcab" minamount="1" maxamount="2" spawnprobability="0.5" />
-      <PreferredContainer primary="medfabcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medfabcab" secondary="medcontainer" />
       <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.2" />
       <Price baseprice="40">
         <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="10" />
       </Price>
-      <SuitableTreatment identifier="opiateoverdose" suitability="-8.75"/>
-      <SuitableTreatment identifier="opiatewithdrawal" suitability="15"/>
-      <SuitableTreatment identifier="pain" suitability="20"/>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="512,768,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="406,452,29,58" depth="0.6"
-              origin="0.5,0.5"/>
-      <Body width="30" height="58" density="20"/>
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+      <SuitableTreatment identifier="opiateoverdose" suitability="-8.75" />
+      <SuitableTreatment identifier="opiatewithdrawal" suitability="15" />
+      <SuitableTreatment identifier="pain" suitability="20" />
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="512,768,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="406,452,29,58" depth="0.6" origin="0.5,0.5" />
+      <Body width="30" height="58" density="20" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
         <RequiredSkill identifier="medical" level="15"></RequiredSkill>
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="5">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="analgesia" amount="4"/>
-          <Affliction identifier="opiateaddiction" amount="1"/>
-          <Affliction identifier="opiateoverdose" amount="1.75"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="3"/>
+          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+          <Affliction identifier="analgesia" amount="4" />
+          <Affliction identifier="opiateaddiction" amount="1" />
+          <Affliction identifier="opiateoverdose" amount="1.75" />
+          <ReduceAffliction identifier="opiatewithdrawal" amount="3" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="5">
           <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="4"/>
-          <Affliction identifier="opiateoverdose" amount="2"/>
+          <Affliction identifier="analgesia" amount="4" />
+          <Affliction identifier="opiateoverdose" amount="2" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="5">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="3"/>
-          <Affliction identifier="opiateoverdose" amount="3"/>
-          <Affliction identifier="opiateaddiction" amount="4"/>
-          <Affliction identifier="analgesia" amount="2"/>
+          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+          <ReduceAffliction identifier="opiatewithdrawal" amount="3" />
+          <Affliction identifier="opiateoverdose" amount="3" />
+          <Affliction identifier="opiateaddiction" amount="4" />
+          <Affliction identifier="analgesia" amount="2" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="5">
           <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="2"/>
-          <Affliction identifier="opiateoverdose" amount="3"/>
+          <Affliction identifier="analgesia" amount="2" />
+          <Affliction identifier="opiateoverdose" amount="3" />
         </StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
     </Item>
-    <Item name="" identifier="antidama1" aliases="Corrigodone" category="Medical" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description=""
-          useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
+    <Item name="" identifier="antidama1" aliases="Corrigodone" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer secondary="supplycab" minamount="1" maxamount="2" spawnprobability="0.5" notcampaign="true"/>
+      <PreferredContainer secondary="supplycab" minamount="1" maxamount="2" spawnprobability="0.5" notcampaign="true" />
       <PreferredContainer secondary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.3" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.8" />
       <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.5" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.1" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="100" minavailable="12">
-        <Price storeidentifier="merchantoutpost"/>
-        <Price storeidentifier="merchantcity"/>
-        <Price storeidentifier="merchantresearch"/>
-        <Price storeidentifier="merchantmilitary"/>
-        <Price storeidentifier="merchantmine"/>
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantoutpost" />
+        <Price storeidentifier="merchantcity" />
+        <Price storeidentifier="merchantresearch" />
+        <Price storeidentifier="merchantmilitary" />
+        <Price storeidentifier="merchantmine" />
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
-      <SuitableTreatment identifier="opiatewithdrawal" suitability="30"/>
-      <SuitableTreatment identifier="opiateoverdose" suitability="-10"/>
-      <SuitableTreatment identifier="opiateaddiction" suitability="-5"/>
-      <SuitableTreatment identifier="pain" suitability="40"/>
+      <SuitableTreatment identifier="opiatewithdrawal" suitability="30" />
+      <SuitableTreatment identifier="opiateoverdose" suitability="-10" />
+      <SuitableTreatment identifier="opiateaddiction" suitability="-5" />
+      <SuitableTreatment identifier="pain" suitability="40" />
       <Fabricate suitablefabricators="medicalfabricator" requiredtime="30">
         <RequiredSkill identifier="medical" level="18" />
         <RequiredItem identifier="opium" amount="2" />
@@ -3232,76 +2881,68 @@
       <Deconstruct time="20">
         <Item identifier="opium" />
       </Deconstruct>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="256,448,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,37,69" depth="0.6" origin="0.5,0.5"/>
-      <Body width="35" height="65" density="20"/>
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="30"/>
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="256,448,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="0,0,37,69" depth="0.6" origin="0.5,0.5" />
+      <Body width="35" height="65" density="20" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+        <RequiredSkill identifier="medical" level="30" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="opiateaddiction" amount="1"/>
-          <Affliction identifier="opiateoverdose" amount="1.0"/>
-          <Affliction identifier="analgesia" amount="5"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="3.0"/>
+          <Affliction identifier="opiateaddiction" amount="1" />
+          <Affliction identifier="opiateoverdose" amount="1.0" />
+          <Affliction identifier="analgesia" amount="5" />
+          <ReduceAffliction identifier="opiatewithdrawal" amount="3.0" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10">
           <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="5"/>
-          <Affliction identifier="opiateoverdose" amount="1"/>
+          <Affliction identifier="analgesia" amount="5" />
+          <Affliction identifier="opiateoverdose" amount="1" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="analgesia" amount="3"/>
-          <Affliction identifier="opiateaddiction" amount="2.5"/>
-          <Affliction identifier="opiateoverdose" amount="2.0"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="3.0"/>
+          <Affliction identifier="analgesia" amount="3" />
+          <Affliction identifier="opiateaddiction" amount="2.5" />
+          <Affliction identifier="opiateoverdose" amount="2.0" />
+          <ReduceAffliction identifier="opiatewithdrawal" amount="3.0" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10">
           <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="3"/>
-          <Affliction identifier="opiateoverdose" amount="2"/>
+          <Affliction identifier="analgesia" amount="3" />
+          <Affliction identifier="opiateoverdose" amount="2" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="10">
-          <Affliction identifier="analgesia" amount="2"/>
-          <Affliction identifier="opiateaddiction" amount="2.5"/>
-          <Affliction identifier="opiateoverdose" amount="2.0"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="3.0"/>
-        </StatusEffect>
-      <StatusEffect tags="medical" type="OnImpact" target="Character" duration="10">
-          <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="2"/>
-          <Affliction identifier="opiateoverdose" amount="2"/>
-        </StatusEffect>
-      </Projectile>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-    <Item name="" identifier="antidama2" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5"
-          impactsoundtag="impact_metal_light">
+    <Item name="" identifier="antidama2" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.4" />
       <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.3" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.1" />
       <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.05" />
       <Price baseprice="250">
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
-      <SuitableTreatment identifier="pain" suitability="50"/>
-      <SuitableTreatment identifier="opiatewithdrawal" suitability="100"/>
-      <SuitableTreatment identifier="opiateoverdose" suitability="-22.5"/>
-      <SuitableTreatment identifier="opiateaddiction" suitability="-7.5"/>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="45" >
+      <SuitableTreatment identifier="pain" suitability="50" />
+      <SuitableTreatment identifier="opiatewithdrawal" suitability="100" />
+      <SuitableTreatment identifier="opiateoverdose" suitability="-22.5" />
+      <SuitableTreatment identifier="opiateaddiction" suitability="-7.5" />
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="45">
         <RequiredSkill identifier="medical" level="50" />
         <RequiredItem identifier="antidama1" />
         <RequiredItem identifier="adrenaline" />
@@ -3312,68 +2953,63 @@
         <Item identifier="adrenaline" mincondition="0.9" />
         <Item identifier="ethanol" mincondition="0.9" />
       </Deconstruct>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="320,448,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="37,0,38,69" depth="0.6" origin="0.5,0.5"/>
-      <Body width="35" height="65" density="20"/>
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <RequiredSkill identifier="medical" level="72"/>
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="320,448,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="37,0,38,69" depth="0.6" origin="0.5,0.5" />
+      <Body width="35" height="65" density="20" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+        <RequiredSkill identifier="medical" level="72" />
+		<StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+		<StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="5">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="analgesia" amount="15"/>
-          <Affliction identifier="opiateaddiction" amount="3"/>
-          <Affliction identifier="opiateoverdose" amount="4.5"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="20"/>
+          <Affliction identifier="analgesia" amount="15" />
+          <Affliction identifier="opiateaddiction" amount="3" />
+          <Affliction identifier="opiateoverdose" amount="4.5" />
+          <ReduceAffliction identifier="opiatewithdrawal" amount="20" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="5">
           <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="15"/>
-          <Affliction identifier="opiateoverdose" amount="4.5"/>
+          <Affliction identifier="analgesia" amount="15" />
+          <Affliction identifier="opiateoverdose" amount="4.5" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="5">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="analgesia" amount="10"/>
-          <Affliction identifier="opiateaddiction" amount="8"/>
-          <Affliction identifier="opiateoverdose" amount="6"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="20"/>
+          <Affliction identifier="analgesia" amount="10" />
+          <Affliction identifier="opiateaddiction" amount="8" />
+          <Affliction identifier="opiateoverdose" amount="6" />
+          <ReduceAffliction identifier="opiatewithdrawal" amount="20" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="5">
           <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="10"/>
-          <Affliction identifier="opiateoverdose" amount="6"/>
+          <Affliction identifier="analgesia" amount="10" />
+          <Affliction identifier="opiateoverdose" amount="6" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true"/>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="5">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="analgesia" amount="5.75"/>
-          <Affliction identifier="opiateaddiction" amount="6"/>
-          <Affliction identifier="opiateoverdose" amount="6"/>
-          <ReduceAffliction identifier="opiatewithdrawal" amount="20"/>
-        </StatusEffect>
-      <StatusEffect tags="medical" type="OnImpact" target="Character" duration="5">
-          <Conditional drunk="gt 30" />
-          <Affliction identifier="analgesia" amount="5"/>
-          <Affliction identifier="opiateoverdose" amount="6"/>
-        </StatusEffect>
-      </Projectile>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
     <Item name="" identifier="antinarc" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.5" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.2" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="160">
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="30" >
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="30">
         <RequiredSkill identifier="medical" level="23" />
         <RequiredItem identifier="antidama1" />
         <RequiredItem identifier="stabilozine" />
@@ -3386,47 +3022,44 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="704,448,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="186,0,38,69" depth="0.6" origin="0.5,0.5" />
       <Body width="35" height="70" density="20" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="39"></RequiredSkill>
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="30.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <ReduceAffliction identifier="opiatewithdrawal" amount="2.0" />
           <ReduceAffliction identifier="opiateoverdose" amount="2.0" />
           <ReduceAffliction identifier="analgesia" amount="2.0" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="30.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <ReduceAffliction identifier="opiatewithdrawal" amount="1.0" />
           <ReduceAffliction identifier="opiateoverdose" amount="1.0" />
           <ReduceAffliction identifier="analgesia" amount="2.0" />
           <Affliction identifier="coma" amount="0.5" probability="0.5" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="30">
-          <ReduceAffliction identifier="opiatewithdrawal" amount="1.0" />
-          <ReduceAffliction identifier="opiateaddiction" amount="1.0" />
-          <ReduceAffliction identifier="opiateoverdose" amount="1.0" />
-          <ReduceAffliction identifier="analgesia" amount="2.0" />
-          <Affliction identifier="oxygenlow" amount="1.0" />
-        </StatusEffect>
-      </Projectile>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- Antibiotics, Adrenaline -->
-    <Item name="" identifier="antibiotics" category="Medical" maxstacksize="8"
-          Tags="smallitem,chem,medical,syringe" description="" cargocontaineridentifier="mediccrate" scale="0.5"
-          useinhealthinterface="true">
+    <!-- Antibiotics, Adrenaline -->
+    <Item name="" identifier="antibiotics" category="Medical" maxstacksize="8" Tags="smallitem,chem,medical,syringe" description="" cargocontaineridentifier="mediccrate" scale="0.5" useinhealthinterface="true">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="abandonedmedcab,wreckmedcab" minamount="1" maxamount="2" spawnprobability="0.5" />
-      <PreferredContainer primary="medfabcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medfabcab" secondary="medcontainer" />
       <Price baseprice="40">
         <Price storeidentifier="merchantoutpost" minavailable="6" />
         <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="12" />
@@ -3435,54 +3068,52 @@
         <Price storeidentifier="merchantmine" sold="false" multiplier="1.1" />
         <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="10" />
       </Price>
-      <Fabricate suitablefabricators="vendingmachine" requiredtime="1" requiredmoney="60" fabricationlimitmin="5" fabricationlimitmax="10"/>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,704,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="263,142,36,68" depth="0.6"
-              origin="0.5,0.5"/>
-      <Body width="35" height="70" density="20"/>
-      <SuitableTreatment identifier="damage" suitability="-33"/>
-      <SuitableTreatment identifier="huskinfection" suitability="30"/>
-      <SuitableTreatment identifier="sepsis" suitability="50"/>
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <RequiredSkill identifier="medical" level="25"/>
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+      <Fabricate suitablefabricators="vendingmachine" requiredtime="1" requiredmoney="60" fabricationlimitmin="5" fabricationlimitmax="10" />
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,704,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="263,142,36,68" depth="0.6" origin="0.5,0.5" />
+      <Body width="35" height="70" density="20" />
+      <SuitableTreatment identifier="damage" suitability="-33" />
+      <SuitableTreatment identifier="huskinfection" suitability="30" />
+      <SuitableTreatment identifier="sepsis" suitability="50" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+        <RequiredSkill identifier="medical" level="25" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="10.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="afantibiotics" amount="5"/>
-          <Affliction identifier="bloodpressure" amount="2"/>
+          <Affliction identifier="afantibiotics" amount="5" />
+          <Affliction identifier="bloodpressure" amount="2" />
         </StatusEffect>
         <StatusEffect type="OnSuccess" target="UseTarget" disabledeltatime="true">
           <Affliction identifier="huskinfectionresistance" amount="600" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="10.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-          <Affliction identifier="afantibiotics" amount="3"/>
-          <Affliction identifier="bloodpressure" amount="2"/>
+          <Affliction identifier="afantibiotics" amount="3" />
+          <Affliction identifier="bloodpressure" amount="2" />
         </StatusEffect>
         <StatusEffect type="OnFailure" target="UseTarget" disabledeltatime="true">
           <Affliction identifier="huskinfectionresistance" amount="300" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
-          <Remove/>
+          <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Limb" duration="10">
-          <Affliction identifier="afantibiotics" amount="3"/>
-          <Affliction identifier="bloodpressure" amount="2"/>
-        </StatusEffect>
-      </Projectile>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-    <Item name="" identifier="adrenaline" category="Medical,Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" scale="0.5"
-          impactsoundtag="impact_metal_light">
+    <Item name="" identifier="adrenaline" category="Medical,Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medfabcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medfabcab" secondary="medcontainer" />
       <PreferredContainer secondary="abandonedmedcab,wreckmedcab" minamount="1" maxamount="2" spawnprobability="0.5" />
       <Price baseprice="60">
         <Price storeidentifier="merchantoutpost" sold="false" multiplier="1.25" />
@@ -3492,31 +3123,19 @@
         <Price storeidentifier="merchantmine" sold="false" multiplier="1.1" />
         <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="4" />
       </Price>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,768,64,64" origin="0.5,0.5"/>
-      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="379,452,27,58" depth="0.55"
-              origin="0.5,0.5"/>
-      <Body width="25" height="55" density="20"/>
-      <SuitableTreatment identifier="cardiacarrest" suitability="100"/>
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,0"
-                   handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-      </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" duration="60" Condition="-100.0" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="1">
-          <Affliction identifier="afadrenaline" amount="30"/>
-          <Affliction identifier="bloodpressure" amount="5"/>
-        </StatusEffect>
-        <!-- TODO: some effect for adrenaline -->
-      </Projectile>
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,768,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="379,452,27,58" depth="0.55" origin="0.5,0.5" />
+      <Body width="25" height="55" density="20" />
+      <SuitableTreatment identifier="cardiacarrest" suitability="100" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true"></MeleeWeapon>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="false" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- Flamer -->
+    <!-- Flamer -->
     <Item name="" identifier="flamer" category="Equipment" Tags="smallitem,weapon,gun,mountableweapon" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="secarmcab" amount="1" spawnprobability="0.2" notcampaign="true"/>
-      <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.1"/>
-      <PreferredContainer secondary="armcab,weaponholder"/>
+      <PreferredContainer primary="secarmcab" amount="1" spawnprobability="0.2" notcampaign="true" />
+      <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.1" />
+      <PreferredContainer secondary="armcab,weaponholder" />
       <Price baseprice="105" sold="false">
         <Price storeidentifier="merchantoutpost" />
         <Price storeidentifier="merchantcity" multiplier="0.9" />
@@ -3548,20 +3167,20 @@
         <RequiredItems items="weldingtoolfuel,oxygensource" type="Contained" msg="ItemMsgWeldingFuelRequired" />
         <RequiredSkill identifier="weapons" level="50" />
         <ParticleEmitterHitCharacter particle="fleshsmoke" particlespersecond="3" anglemin="-5" anglemax="5" velocitymin="10" velocitymax="100" />
-        <ParticleEmitter particle="flamethrower" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="1000" velocitymax="1500" highqualitycollisiondetection="true"/>
-        <ParticleEmitter particle="flamethrowersmoke" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="500" velocitymax="1000"/>
+        <ParticleEmitter particle="flamethrower" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="1000" velocitymax="1500" highqualitycollisiondetection="true" />
+        <ParticleEmitter particle="flamethrowersmoke" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="500" velocitymax="1000" />
         <sound file="Content/Items/Weapons/FlameThrowerLoop.ogg" type="OnUse" range="500.0" loop="true" />
         <StatusEffect type="OnFailure" target="This">
-          <ParticleEmitter particle="bubbles" particlespersecond="20" anglemin="-10" anglemax="10" scalemin="0.3" scalemax="0.7" velocitymin="5" velocitymax="100" copyentityangle="true"/>
-          <ParticleEmitter particle="fleshsmoke" particlespersecond="10" anglemin="-10" anglemax="10" scalemin="1" scalemax="1.5" velocitymin="5" velocitymax="200" copyentityangle="true"/>
+          <ParticleEmitter particle="bubbles" particlespersecond="20" anglemin="-10" anglemax="10" scalemin="0.3" scalemax="0.7" velocitymin="5" velocitymax="100" copyentityangle="true" />
+          <ParticleEmitter particle="fleshsmoke" particlespersecond="10" anglemin="-10" anglemax="10" scalemin="1" scalemax="1.5" velocitymin="5" velocitymax="200" copyentityangle="true" />
         </StatusEffect>
         <!-- make the item unusable when there's less than 10% oxygen -->
         <StatusEffect type="OnUse" target="Hull,This" UsableIn="None">
-          <Conditional OxygenPercentage="lt 10"/>
+          <Conditional OxygenPercentage="lt 10" />
         </StatusEffect>
         <!-- make the item usable again when there's more than 10% oxygen -->
         <StatusEffect type="OnUse" target="Hull,This" UsableIn="Air">
-          <Conditional OxygenPercentage="gt 10"/>
+          <Conditional OxygenPercentage="gt 10" />
         </StatusEffect>
         <!-- when using, the contained welding fuel tank will detoriate (= lose fuel) -->
         <StatusEffect type="OnUse" targettype="Contained" targets="weldingfueltank" Condition="-6.0" />
@@ -3575,7 +3194,7 @@
         <StatusEffect type="OnUse" targettype="Contained" targets="oxygentank" delay="1.0" stackable="false" Condition="-100.0" disabledeltatime="true">
           <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="5000" />
           <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="5000" />
-          <Explosion range="150.0" force="3" applyfireeffects="false" >
+          <Explosion range="150.0" force="3" applyfireeffects="false">
             <Affliction identifier="burn" strength="25" />
             <Affliction identifier="stun" strength="5" />
           </Explosion>
@@ -3583,16 +3202,16 @@
         <StatusEffect type="OnUse" targettype="Contained" targets="oxygenitetank" delay="1.0" stackable="false" Condition="-100.0" disabledeltatime="true">
           <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="5000" />
           <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="5000" />
-          <Explosion range="150.0" force="6" applyfireeffects="false" >
+          <Explosion range="150.0" force="6" applyfireeffects="false">
             <Affliction identifier="burn" strength="50" />
             <Affliction identifier="stun" strength="10" />
           </Explosion>
         </StatusEffect>
         <!-- consume oxygen from the hull -->
-        <StatusEffect type="OnUse" target="Hull" Oxygen="-10000"/>
+        <StatusEffect type="OnUse" target="Hull" Oxygen="-10000" />
         <StatusEffect type="OnFailure" target="Character">
-          <Conditional InWater="false"/>
-          <Affliction identifier="burn" strength="0.5" probability="0.5"/>
+          <Conditional InWater="false" />
+          <Affliction identifier="burn" strength="0.5" probability="0.5" />
         </StatusEffect>
         <LightComponent LightColor="255,174,121,255" Flicker="0.5" Range="500">
           <sprite texture="Content/Items/Electricity/lightsprite.png" origin="0.5,0.5" />
@@ -3604,11 +3223,11 @@
       </ItemContainer>
       <aitarget sightrange="5000" soundrange="500" fadeouttime="5" />
     </Item>
-  <!-- Fire extinguisher -->
+    <!-- Fire extinguisher -->
     <Item name="" identifier="extinguisher" category="Equipment" Tags="mediumitem,fireextinguisher,provocative" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_metal_light" donttransferbetweensubs="true">
       <Upgrade gameversion="0.9.600.0" Tags="mediumitem,fireextinguisher,provocative" />
-      <PreferredContainer primary="extinguisherholder" spawnprobability="1.0"/>
-      <PreferredContainer secondary="engcab,reactorcab"/>
+      <PreferredContainer primary="extinguisherholder" spawnprobability="1.0" />
+      <PreferredContainer secondary="engcab,reactorcab" />
       <Price baseprice="100" displaynonempty="true">
         <Price storeidentifier="merchantoutpost" minavailable="3" />
         <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="4" />
@@ -3618,7 +3237,7 @@
       </Price>
       <Deconstruct time="10">
         <Item identifier="aluminium" />
-	<Item identifier="sodium" mincondition="0.5" />
+        <Item identifier="sodium" mincondition="0.5" />
       </Deconstruct>
       <Fabricate suitablefabricators="fabricator" requiredtime="10">
         <RequiredSkill identifier="mechanical" level="20" />
@@ -3632,8 +3251,8 @@
       <RepairTool extinguishamount="60.0" range="500" barrelpos="21,25" repairthroughholes="true" hititems="false">
         <ParticleEmitter particle="extinguisher" velocitymin="1000.0" velocitymax="1650.0" particlespersecond="100" />
         <StatusEffect type="OnUse" targettype="This" Condition="-2.0" />
-        <StatusEffect type="OnUse" targettype="NearbyCharacters" Condition="-2.0" range="200" >
-          <ReduceAffliction identifier="onfire" amount="1"/>
+        <StatusEffect type="OnUse" targettype="NearbyCharacters" Condition="-2.0" range="200">
+          <ReduceAffliction identifier="onfire" amount="1" />
         </StatusEffect>
         <sound file="Content/Items/Tools/Extinguisher.ogg" type="OnUse" range="500.0" loop="true" />
       </RepairTool>
@@ -3641,24 +3260,23 @@
       <aitarget sightrange="1000" soundrange="1000" fadeouttime="1" />
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
     </Item>
-
-  <!-- captains pipe -->
+    <!-- captains pipe -->
     <Item name="" identifier="captainspipe" category="Misc" Tags="smallitem" scale="0.5" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true" requireaimtouse="true">
-      <PreferredContainer primary="crewcab" spawnprobability="0.05" notcampaign="true"/>
-      <PreferredContainer secondary="wreckcrewcab,abandonedcrewcab" spawnprobability="0.1"/>
+      <PreferredContainer primary="crewcab" spawnprobability="0.05" notcampaign="true" />
+      <PreferredContainer secondary="wreckcrewcab,abandonedcrewcab" spawnprobability="0.1" />
       <Price baseprice="50">
-        <Price storeidentifier="merchantoutpost"/>
-        <Price storeidentifier="merchantcity"/>
-        <Price storeidentifier="merchantresearch"/>
-        <Price storeidentifier="merchantmilitary"/>
-        <Price storeidentifier="merchantmine"/>
+        <Price storeidentifier="merchantoutpost" />
+        <Price storeidentifier="merchantcity" />
+        <Price storeidentifier="merchantresearch" />
+        <Price storeidentifier="merchantmilitary" />
+        <Price storeidentifier="merchantmine" />
       </Price>
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="511,957,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Misc/Misc.png" sourcerect="105,73,50,30" depth="0.55" origin="0.5,0.5" />
       <Body width="58" height="20" />
       <Holdable slots="Any,RightHand" aimable="false" aimpos="28,10" handle1="10,-5" swingamount="0,0" swingspeed="0.5" swingwhenusing="true" msg="ItemMsgPickUpSelect">
         <StatusEffect type="OnUse" target="This">
-          <ParticleEmitter particle="swirlysmoke" particlespersecond="1" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10"/>
+          <ParticleEmitter particle="swirlysmoke" particlespersecond="1" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
           <RequiredItem items="pipetobacco" type="Contained" />
         </StatusEffect>
         <StatusEffect type="OnUse" target="Contained" Condition="-4.0" disabledeltatime="false">
@@ -3676,9 +3294,9 @@
         <Containable items="pipetobacco" />
       </ItemContainer>
     </Item>
-  <!-- cigar -->
+    <!-- cigar -->
     <Item name="" identifier="cigar" category="Misc" Tags="smallitem" scale="0.5" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" isshootable="true" requireaimtouse="true">
-      <PreferredContainer primary="crewcab"/>
+      <PreferredContainer primary="crewcab" />
       <Price baseprice="130" sold="false" />
       <Fabricate suitablefabricators="fabricator" requiredtime="5" requiresrecipe="true">
         <RequiredItem identifier="pipetobacco" />
@@ -3703,23 +3321,23 @@
         </StatusEffect>
       </Holdable>
     </Item>
-  <!-- liquid oxygenite -->
+    <!-- liquid oxygenite -->
     <Item name="" identifier="liquidoxygenite" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" impacttolerance="8" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <Price baseprice="80">
         <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="4" />
       </Price>
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
-      <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.1" />  
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
+      <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.1" />
       <SuitableTreatment identifier="hypoxemia" suitability="100" />
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="704,640,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="187,138,38,71" depth="0.6" origin="0.5,0.5" />
       <Body width="35" height="70" density="20" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="72" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="30.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="organdamage" amount="0.2" />
           <Affliction identifier="kidneydamage" amount="0.2" />
           <Affliction identifier="heartdamage" amount="0.2" />
@@ -3728,7 +3346,6 @@
           <ReduceAffliction identifier="hypoxemia" amount="100" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="20.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="organdamage" amount="0.5" />
           <Affliction identifier="kidneydamage" amount="0.5" />
           <Affliction identifier="heartdamage" amount="0.5" />
@@ -3744,23 +3361,34 @@
             <Affliction identifier="stun" amount="2" />
           </Explosion>
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- deusizine -->
+    <!-- deusizine -->
     <Item name="" identifier="deusizine" aliases="Auxiliriozine" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.2" />
       <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.02" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="500">
-        <Price storeidentifier="merchantmedical" multiplier="0.9" minleveldifficulty="50"/>
+        <Price storeidentifier="merchantmedical" multiplier="0.9" minleveldifficulty="50" />
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="60" >
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="60">
         <RequiredSkill identifier="medical" level="70" />
         <RequiredItem identifier="antibleeding3" />
         <RequiredItem identifier="antidama2" />
@@ -3777,11 +3405,11 @@
       <SuitableTreatment identifier="hypoxemia" suitability="45" />
       <SuitableTreatment type="bloodloss" suitability="30" />
       <SuitableTreatment type="burn" suitability="-25" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="72" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="20">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="burn" amount="0.2" />
           <Affliction identifier="bloodpressure" amount="2" />
           <ReduceAffliction type="organdamage" amount="2" />
@@ -3790,7 +3418,6 @@
           <ReduceAffliction identifier="bloodloss" amount="2" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="20">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="burn" amount="0.6" />
           <Affliction identifier="bloodpressure" amount="1" />
           <ReduceAffliction type="organdamage" amount="1" />
@@ -3798,24 +3425,35 @@
           <ReduceAffliction identifier="hypoxemia" amount="2" />
           <ReduceAffliction identifier="bloodloss" amount="1" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- antibiotic glue -->
+    <!-- antibiotic glue -->
     <Item name="" identifier="antibleeding3" category="Medical" Tags="smallitem,medical" maxstacksize="8" cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.3" />
       <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.05" />
       <Price baseprice="140">
         <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="10" minleveldifficulty="25" />
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="45" amount="2" >
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="45" amount="2">
         <RequiredSkill identifier="medical" level="48" />
         <RequiredItem identifier="stabilozine" amount="2" />
         <RequiredItem identifier="antibiotics" amount="3" />
@@ -3857,13 +3495,13 @@
         </StatusEffect>
       </MeleeWeapon>
     </Item>
-  <!-- meth -->
+    <!-- meth -->
     <Item name="" identifier="meth" category="Medical" maxstacksize="8" cargocontaineridentifier="chemicalcrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medcab"/>
+      <PreferredContainer primary="medcab" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="abandonedcrewcab" amount="1" spawnprobability="0.05" />
-      <PreferredContainer secondary="crewcab" amount="1" spawnprobability="0.05" notcampaign="true"/>
+      <PreferredContainer secondary="crewcab" amount="1" spawnprobability="0.05" notcampaign="true" />
       <Price baseprice="50">
         <Price storeidentifier="merchantoutpost" sold="false" />
         <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
@@ -3885,9 +3523,10 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="512,448,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="75,0,37,69" depth="0.6" origin="0.5,0.5" />
       <Body width="35" height="65" density="15" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="35" />
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="30.0">
           <Affliction identifier="organdamage" amount="0.5" />
           <Affliction identifier="cerebralhypoxia" amount="0.5" />
@@ -3897,7 +3536,6 @@
           <ReduceAffliction identifier="chemwithdrawal" amount="3" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="haste" amount="420" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="30.0">
@@ -3909,39 +3547,33 @@
           <ReduceAffliction identifier="chemwithdrawal" amount="3" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="haste" amount="300" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" disabledeltatime="true">
-          <Affliction identifier="haste" amount="300" />
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="30.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-          <Affliction identifier="organdamage" amount="1" />
-          <Affliction identifier="cerebralhypoxia" amount="1" />
-          <Affliction identifier="psychosis" amount="1.5" />
-          <ReduceAffliction identifier="stun" amount="0.75" />
-          <Affliction identifier="chemaddiction" amount="1" />
-          <ReduceAffliction identifier="chemwithdrawal" amount="3" />
-        </StatusEffect>
-      </Projectile>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- hyperzine -->
+    <!-- hyperzine -->
     <Item name="" identifier="hyperzine" category="Medical" maxstacksize="8" cargocontaineridentifier="chemicalcrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medcab"/>
+      <PreferredContainer primary="medcab" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.1" />
       <PreferredContainer secondary="abandonedcrewcab" amount="1" spawnprobability="0.05" />
-      <PreferredContainer secondary="crewcab" amount="1" spawnprobability="0.05" notcampaign="true"/>
+      <PreferredContainer secondary="crewcab" amount="1" spawnprobability="0.05" notcampaign="true" />
       <Price baseprice="450" minavailable="1">
         <Price storeidentifier="merchantoutpost" sold="false" />
         <Price storeidentifier="merchantcity" sold="false" multiplier="0.9" />
@@ -3960,11 +3592,11 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,448,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="149,0,37,69" depth="0.6" origin="0.5,0.5" />
       <Body width="35" height="65" density="15" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-5,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="50" />
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="60.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <ReduceAffliction identifier="internaldamage" amount="0.2" />
           <ReduceAffliction identifier="stun" amount="0.9" />
           <Affliction identifier="chemaddiction" amount="0.3" />
@@ -3977,7 +3609,6 @@
           <Affliction identifier="strengthen" amount="400" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="60.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <!-- TODO: should this be any affliction of type damage?-->
           <ReduceAffliction identifier="internaldamage" amount="0.1" />
           <ReduceAffliction identifier="stun" amount="0.25" />
@@ -3991,38 +3622,30 @@
           <Affliction identifier="haste" amount="400" />
           <Affliction identifier="strengthen" amount="400" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90">
-        <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" duration="60.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-          <!-- TODO: should this be any affliction of type damag?-->
-          <ReduceAffliction identifier="internaldamage" amount="0.1" />
-          <ReduceAffliction identifier="stun" amount="0.25" />
-          <Affliction identifier="chemaddiction" amount="0.6" />
-          <Affliction identifier="cerebralhypoxia" amount="0.6" />
-          <Affliction identifier="psychosis" amount="1" />
-          <ReduceAffliction identifier="chemwithdrawal" amount="1.5" />
-          <Affliction identifier="burn" amount="0.125" />
-        </StatusEffect>
-        <StatusEffect tags="medical" type="OnImpact" target="Character" disabledeltatime="true">
-          <Affliction identifier="haste" amount="400" />
-          <Affliction identifier="strengthen" amount="400" />
-        </StatusEffect>
-      </Projectile>
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- diving knife -->
+    <!-- diving knife -->
     <Item name="" identifier="divingknife" category="Weapon" Tags="smallitem,weapon,gunsmith,mountableweapon" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True" useinhealthinterface="True">
-      <PreferredContainer secondary="wreckarmcab,abandonedarmcab" amount="1" spawnprobability="0.25"/>
-      <PreferredContainer secondary="abandonedstoragecab" amount="1" spawnprobability="0.05"/>
-      <PreferredContainer secondary="beaconsupplycab" amount="1" spawnprobability="0.05"/>
-      <PreferredContainer primary="secarmcab" secondary="armcab"/>
+      <PreferredContainer secondary="wreckarmcab,abandonedarmcab" amount="1" spawnprobability="0.25" />
+      <PreferredContainer secondary="abandonedstoragecab" amount="1" spawnprobability="0.05" />
+      <PreferredContainer secondary="beaconsupplycab" amount="1" spawnprobability="0.05" />
+      <PreferredContainer primary="secarmcab" secondary="armcab" />
       <Price baseprice="29">
         <Price storeidentifier="merchantoutpost" multiplier="1.5" minavailable="6" />
         <Price storeidentifier="merchantcity" multiplier="1.25" minavailable="8" />
@@ -4041,12 +3664,12 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="835,385,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="183,203,66,16" depth="0.55" origin="0.5,0.5" />
       <Body width="65" height="15" density="50" />
-      <SuitableTreatment identifier="dirtybandage" suitability="50"/>
-      <SuitableTreatment identifier="bandaged" suitability="50"/>
-      <SuitableTreatment identifier="triagetag_green" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_yellow" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_red" suitability="100"/>
-      <SuitableTreatment identifier="triagetag_black" suitability="100"/>
+      <SuitableTreatment identifier="dirtybandage" suitability="50" />
+      <SuitableTreatment identifier="bandaged" suitability="50" />
+      <SuitableTreatment identifier="triagetag_green" suitability="100" />
+      <SuitableTreatment identifier="triagetag_yellow" suitability="100" />
+      <SuitableTreatment identifier="triagetag_red" suitability="100" />
+      <SuitableTreatment identifier="triagetag_black" suitability="100" />
       <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="50,0" handle1="-10,0" holdangle="30" reload="0.75" range="50" combatPriority="25" msg="ItemMsgPickUpSelect">
         <Attack targetimpulse="2" severlimbsprobability="0.1" itemdamage="10" structuredamage="10" structuresoundtype="StructureSlash">
           <Affliction identifier="lacerations" strength="10" />
@@ -4064,26 +3687,26 @@
       </MeleeWeapon>
       <aitarget sightrange="500" soundrange="250" fadeouttime="1" />
       <Quality>
-        <QualityStat stattype="StrikingPowerMultiplier" value="0.1"/>
+        <QualityStat stattype="StrikingPowerMultiplier" value="0.1" />
       </Quality>
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
     </Item>
-  <!-- Haloperidol -->
+    <!-- Haloperidol -->
     <Item name="" identifier="antipsychosis" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.06" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="130" minavailable="4">
-        <Price storeidentifier="merchantoutpost"/>
-        <Price storeidentifier="merchantcity"/>
-        <Price storeidentifier="merchantresearch"/>
-        <Price storeidentifier="merchantmilitary"/>
-        <Price storeidentifier="merchantmine"/>
-        <Price storeidentifier="merchantmedical" multiplier="0.9"/>
+        <Price storeidentifier="merchantoutpost" />
+        <Price storeidentifier="merchantcity" />
+        <Price storeidentifier="merchantresearch" />
+        <Price storeidentifier="merchantmilitary" />
+        <Price storeidentifier="merchantmine" />
+        <Price storeidentifier="merchantmedical" multiplier="0.9" />
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="30" >
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="30">
         <RequiredSkill identifier="medical" level="21" />
         <RequiredItem identifier="lithium" />
         <RequiredItem identifier="carbon" amount="2" />
@@ -4098,36 +3721,46 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="512,640,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="37,138,38,71" depth="0.6" origin="0.5,0.5" />
       <Body width="35" height="70" density="20" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="37" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="1">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <ReduceAffliction identifier="psychosis" amount="100" />
           <ReduceAffliction identifier="hallucinating" amount="100" />
           <ReduceAffliction identifier="alcoholwithdrawal" amount="100" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="1">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <ReduceAffliction identifier="psychosis" amount="25" />
           <ReduceAffliction identifier="hallucinating" amount="25" />
           <ReduceAffliction identifier="alcoholwithdrawal" amount="25" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- Anaparalyzant -->
+    <!-- Anaparalyzant -->
     <Item name="" identifier="antiparalysis" category="Medical" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="wrecksupplycab" amount="1" spawnprobability="0.3" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.8" />
       <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.2" />
       <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.06" />
-      <PreferredContainer primary="medcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medcab" secondary="medcontainer" />
       <Price baseprice="200" minleveldifficulty="15">
         <Price storeidentifier="merchantoutpost" />
         <Price storeidentifier="merchantcity" multiplier="0.9" />
@@ -4136,7 +3769,7 @@
         <Price storeidentifier="merchantmine" multiplier="1.1" />
         <Price storeidentifier="merchantmedical" minavailable="2" multiplier="0.9" />
       </Price>
-      <Fabricate suitablefabricators="medicalfabricator" requiredtime="30" >
+      <Fabricate suitablefabricators="medicalfabricator" requiredtime="30">
         <RequiredSkill identifier="medical" level="24" />
         <RequiredItem identifier="paralyzant" />
         <RequiredItem identifier="stabilozine" />
@@ -4148,36 +3781,46 @@
       <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="960,704,64,64" origin="0.5,0.5" />
       <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="150,210,39,69" depth="0.6" origin="0.5,0.5" />
       <Body width="35" height="70" density="20" />
-      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+      <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
         <RequiredSkill identifier="medical" level="64" />
-        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+	    <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+	    <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
         <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" duration="1.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="paralysisresistance" amount="800" />
           <Affliction identifier="psychosis" amount="5" />
           <ReduceAffliction identifier="anesthesia" amount="200" />
         </StatusEffect>
         <StatusEffect tags="medical" type="OnFailure" target="UseTarget" duration="60.0">
-          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
           <Affliction identifier="paralysisresistance" amount="6.5" />
           <Affliction identifier="psychosis" amount="0.75" />
           <ReduceAffliction identifier="anesthesia" amount="3" />
         </StatusEffect>
+		<StatusEffect type="OnSuccess" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnFailure" target="UseTarget">
+		  <Conditional entitytype="eq Character"/>
+		  <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+		</StatusEffect>
+		<StatusEffect type="OnImpact" target="UseTarget" multiplyafflictionsbymaxvitality="true" AllowWhenBroken="true">
+		  <Affliction identifier="stun" amount="0.1" />
+		</StatusEffect>
         <!-- Remove the item when fully used -->
         <StatusEffect type="OnBroken" target="This">
           <Remove />
         </StatusEffect>
       </MeleeWeapon>
-      <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
+      <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     </Item>
-  <!-- Handcuffs -->
+    <!-- Handcuffs -->
     <Item name="" identifier="handcuffs" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,handlocker" scale="0.5" impactsoundtag="impact_metal_light" equipconfirmationtext="handcuffequipconfirmation">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
       <PreferredContainer secondary="wreckarmcab,abandonedarmcab,outpostarmcab" amount="1" spawnprobability="0.05" />
       <PreferredContainer primary="armcab" secondary="secarmcab" />
       <Price baseprice="30">
         <Price storeidentifier="merchantoutpost" minavailable="1" />
-        <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" sold="false"/>
+        <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" sold="false" />
         <Price storeidentifier="merchantresearch" sold="false" />
         <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="3" />
         <Price storeidentifier="merchantmine" sold="false" />
@@ -4194,16 +3837,15 @@
       <Wearable slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" autoequipwhenfull="false">
         <sprite texture="Content/Items/Jobgear/Mechanic/safetyharness.png" limb="RightHand" sourcerect="462,1,25,16" origin="0.5,0.8" depth="0.09" inheritlimbdepth="false" inherittexturescale="true" />
         <sprite texture="Content/Items/Jobgear/Mechanic/safetyharness.png" limb="LeftHand" sourcerect="487,1,25,16" origin="0.5,0.8" depth="0.09" inheritlimbdepth="false" inherittexturescale="true" />
-        <StatusEffect type="OnWearing" target="Character" lockhands="true" setvalue="true" >
-          <Affliction identifier="lockedhands" strength="100"/>
+        <StatusEffect type="OnWearing" target="Character" lockhands="true" setvalue="true">
+          <Affliction identifier="lockedhands" strength="100" />
         </StatusEffect>
       </Wearable>
     </Item>
-
-  <!-- Tonic liquid | change: vanilla heals 12 damage over 120 seconds for whatever reason. this one doesn't.-->
+    <!-- Tonic liquid | change: vanilla heals 12 damage over 120 seconds for whatever reason. this one doesn't.-->
     <Item name="" identifier="tonicliquid" category="Medical,Material" maxstacksize="8" cargocontaineridentifier="chemicalcrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
       <Upgrade gameversion="0.10.0.0" scale="0.5" />
-      <PreferredContainer primary="medfabcab" secondary="medcontainer"/>
+      <PreferredContainer primary="medfabcab" secondary="medcontainer" />
       <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.1" />
       <Price baseprice="75" minavailable="3">
         <Price storeidentifier="merchantoutpost" />
@@ -4212,7 +3854,7 @@
         <Price storeidentifier="merchantmilitary" multiplier="1.1" minavailable="8" />
         <Price storeidentifier="merchantmine" multiplier="1.1" />
       </Price>
-      <Fabricate suitablefabricators="vendingmachine" requiredtime="1" requiredmoney="100" fabricationlimitmin="5" fabricationlimitmax="10"/>
+      <Fabricate suitablefabricators="vendingmachine" requiredtime="1" requiredmoney="100" fabricationlimitmin="5" fabricationlimitmax="10" />
       <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="2">
         <RequiredSkill identifier="medical" level="5" />
         <RequiredItem identifier="calcium" amount="3" />
@@ -4238,55 +3880,51 @@
         </StatusEffect>
       </MeleeWeapon>
     </Item>
-  
-  <!-- Nitroglycerin | change: now acts as blood pressure reducing medicine.-->
-  <Item name="" identifier="nitroglycerin" category="Medical,Material,Weapon" maxstacksize="8" description="" spritecolor="1.0,1.0,1.0,1.0" containercolor="1.0,1.0,1.0,1.0" cargocontaineridentifier="explosivecrate" Tags="smallitem,chem,medical" impacttolerance="6" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
-    <PreferredContainer primary="secarmcab" secondary="armcab"/>
-    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" amount="1" spawnprobability="0.01"/>
-    <Price baseprice="150">
-      <Price storeidentifier="merchantoutpost" sold="false" multiplier="1.4" />
-      <Price storeidentifier="merchantcity" multiplier="1.25" minavailable="2" sold="false"/>
-      <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
-      <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="4" />
-      <Price storeidentifier="merchantmine" sold="false" />
-      <Price storeidentifier="merchantarmory" multiplier="0.9" minavailable="4" />
-      <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="4" />
-    </Price>
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,768,64,64" origin="0.5,0.5" />
-    <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="110,414,31,62" depth="0.6" origin="0.5,0.5" />
-    <Body width="35" height="60" density="20" />
-    <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-      <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true" />
-      <StatusEffect type="OnFire" target="This" Condition="-50.0" />
-      <StatusEffect type="OnBroken" target="This" Condition="-100.0">
-        <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" selectionmode="All" range="8000" />
-        <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" selectionmode="All" range="8000" />
-        <Explosion range="600.0" ballastfloradamage="60" structuredamage="200" itemdamage="1000" force="20.0" severlimbsprobability="0.4" decal="explosion" decalsize="0.5">
-          <Affliction identifier="burn" strength="50" />
-          <Affliction identifier="explosiondamage" strength="50" />
-          <Affliction identifier="stun" strength="5" />
-        </Explosion>
-        <Remove />
-      </StatusEffect>
-
-      <RequiredSkill identifier="medical" level="35" />
-      <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" disabledeltatime="true">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <Affliction identifier="afpressuredrug" amount="100" />
-      </StatusEffect>
-      <StatusEffect tags="medical" type="OnSuccess" target="This" disabledeltatime="true">
-        <Remove/>
-      </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="UseTarget" disabledeltatime="true">
-        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <Affliction identifier="afpressuredrug" amount="50" />
-      </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="This" disabledeltatime="true">
-        <Remove/>
-      </StatusEffect>
-
-    </Throwable>
-  </Item>
-
+    <!-- Nitroglycerin | change: now acts as blood pressure reducing medicine.-->
+    <Item name="" identifier="nitroglycerin" category="Medical,Material,Weapon" maxstacksize="8" description="" spritecolor="1.0,1.0,1.0,1.0" containercolor="1.0,1.0,1.0,1.0" cargocontaineridentifier="explosivecrate" Tags="smallitem,chem,medical" impacttolerance="6" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
+      <PreferredContainer primary="secarmcab" secondary="armcab" />
+      <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" amount="1" spawnprobability="0.01" />
+      <Price baseprice="150">
+        <Price storeidentifier="merchantoutpost" sold="false" multiplier="1.4" />
+        <Price storeidentifier="merchantcity" multiplier="1.25" minavailable="2" sold="false" />
+        <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
+        <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="4" />
+        <Price storeidentifier="merchantmine" sold="false" />
+        <Price storeidentifier="merchantarmory" multiplier="0.9" minavailable="4" />
+        <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="4" />
+      </Price>
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,768,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="110,414,31,62" depth="0.6" origin="0.5,0.5" />
+      <Body width="35" height="60" density="20" />
+      <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+        <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true" />
+        <StatusEffect type="OnFire" target="This" Condition="-50.0" />
+        <StatusEffect type="OnBroken" target="This" Condition="-100.0">
+          <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" selectionmode="All" range="8000" />
+          <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" selectionmode="All" range="8000" />
+          <Explosion range="600.0" ballastfloradamage="60" structuredamage="200" itemdamage="1000" force="20.0" severlimbsprobability="0.4" decal="explosion" decalsize="0.5">
+            <Affliction identifier="burn" strength="50" />
+            <Affliction identifier="explosiondamage" strength="50" />
+            <Affliction identifier="stun" strength="5" />
+          </Explosion>
+          <Remove />
+        </StatusEffect>
+        <RequiredSkill identifier="medical" level="35" />
+        <StatusEffect tags="medical" type="OnSuccess" target="UseTarget" disabledeltatime="true">
+          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+          <Affliction identifier="afpressuredrug" amount="100" />
+        </StatusEffect>
+        <StatusEffect tags="medical" type="OnSuccess" target="This" disabledeltatime="true">
+          <Remove />
+        </StatusEffect>
+        <StatusEffect tags="medical" type="OnFailure" target="UseTarget" disabledeltatime="true">
+          <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
+          <Affliction identifier="afpressuredrug" amount="50" />
+        </StatusEffect>
+        <StatusEffect tags="medical" type="OnFailure" target="This" disabledeltatime="true">
+          <Remove />
+        </StatusEffect>
+      </Throwable>
+    </Item>
   </Override>
 </Items>


### PR DESCRIPTION
Made it so:

Arms aren't twisted behind back when holding syringe.
Syringes can be used in syringe guns correctly (except for streptokinase, propofol, and adrenaline, due to their effects applied via LUA)
Updated sound trigger to match Barotrauma core format (unsure what the effects are)
----
This
`        <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />`
Replaced with this
```
        <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
        <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
```
Old projectile code sections replaced with this:
`<Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />`
This added to MeleeWeapon
`HitOnlyCharacters="true"`
This added to syringes to match core, while old sounds removed from the medical status effects
```
      <StatusEffect type="OnSuccess" target="UseTarget">
        <Conditional entitytype="eq Character"/>
        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
      </StatusEffect>
      <StatusEffect type="OnFailure" target="UseTarget">
        <Conditional entitytype="eq Character"/>
        <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
      </StatusEffect>
```