### PR TITLE
Dementonite & hardened screwdriver recipe fix

### DIFF
--- a/NT Cybernetics/Xml/items.xml
+++ b/NT Cybernetics/Xml/items.xml
@@ -237,7 +237,7 @@
         <Item identifier="depletedfuel" />
       </Deconstruct>
       <Fabricate requiresrecipe="true">
-        <RequiredItem identifier="screwdriver" />
+        <RequiredItem identifier="screwdriver" amount="1" />
         <RequiredItem identifier="depletedfuel" amount="2" />
       </Fabricate>
       <SuitableTreatment identifier="ntc_loosescrews" suitability="50"/>
@@ -265,7 +265,7 @@
         <Item identifier="dementonite" />
       </Deconstruct>
       <Fabricate requiresrecipe="true">
-        <RequiredItem identifier="screwdriver" />
+        <RequiredItem identifier="screwdriver" amount="1" />
         <RequiredItem identifier="dementonite" amount="2" />
       </Fabricate>
       <SuitableTreatment identifier="ntc_loosescrews" suitability="50"/>


### PR DESCRIPTION
The cybernetics override for the dementonite & hardened screwdriver recipes don't include an amount for the screwdriver requirement, so it defaults to the base recipe's 2 item requirement.