### PR TITLE
remove function call with deprecated necrosis aff

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -697,7 +697,6 @@ NT.ItemMethods.tweezers = function(item, usingCharacter, targetCharacter, limb)
             if usecase=="surgery" then
                 healAfflictionGiveSkill("internaldamage",5,3)
                 healAfflictionGiveSkill("blunttrauma",5,3)
-                healAfflictionGiveSkill("necrosis",5,1)
             end
         else
             HF.AddAfflictionLimb(targetCharacter,"internaldamage",limbtype,6,usingCharacter)


### PR DESCRIPTION
function calls for a nonexistent(deprecated) "necrosis" affliction identifier, in case of tweezers, necrosis is no longer a thing in the mod

this change fixes a SV Lua error when you used tweezers after retracted skin